### PR TITLE
Add libtelemetry CI instrumentation tests support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           name: Check code style
           command: make checkstyle
       - run:
+          name: Run Lint
+          command: ./gradlew lint
+      - run:
           name: Run unit-test in Android libraries
           command: make test
       - run:
@@ -41,6 +44,9 @@ jobs:
           command: |
             ./gradlew accessToken
             ./gradlew app:assembleDebug
+      - run:
+          name: Build libtelemetry test APK
+          command: ./gradlew libtelemetry:assembleDebugAndroidTest
       - run:
           name: Log in to Google Cloud Platform
           shell: /bin/bash -euo pipefail
@@ -53,7 +59,7 @@ jobs:
           no_output_timeout: 1200
           shell: /bin/bash -euo pipefail
           command: |
-            gcloud firebase test android run --type robo --app app/build/outputs/apk/app-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/app-debug.apk --test libtelemetry/build/outputs/apk/libtelemetry-debug-androidTest.apk --device model=Nexus5,version=23,locale=en,orientation=portrait --timeout 10m
       - store_artifacts:
           path: app/build/reports
           destination: reports


### PR DESCRIPTION
- Adds `libtelemetry` CI instrumentation tests support
  - Fixes #10 
- Adds Lint check step

👀 @electrostat 