### PR TITLE
Make Location Engine priority editable

### DIFF
--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/AndroidLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/AndroidLocationEngine.java
@@ -81,7 +81,7 @@ class AndroidLocationEngine extends LocationEngine implements LocationListener {
   }
 
   @Override
-  public void setPriority(int priority) {
+  public void setPriority(@LocationEnginePriority.PowerMode int priority) {
     super.setPriority(priority);
     updateCurrentProvider();
   }

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/LocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/LocationEngine.java
@@ -2,7 +2,6 @@ package com.mapbox.services.android.core.location;
 
 import android.Manifest;
 import android.location.Location;
-import android.support.annotation.IntRange;
 import android.support.annotation.RequiresPermission;
 import android.support.annotation.Size;
 
@@ -24,7 +23,7 @@ public abstract class LocationEngine {
 
   private static final int TWO_MINUTES = 1000 * 60 * 2;
 
-  protected int priority;
+  protected @LocationEnginePriority.PowerMode int priority;
   protected Integer interval = 1000;
   protected Integer fastestInterval = 1000;
   protected Float smallestDisplacement = 3.0f;
@@ -103,7 +102,7 @@ public abstract class LocationEngine {
    * @return Integer representing one of the priorities listed inside the {@link LocationEnginePriority} file.
    * @since 2.0.0
    */
-  public int getPriority() {
+  public @LocationEnginePriority.PowerMode int getPriority() {
     return priority;
   }
 
@@ -115,7 +114,7 @@ public abstract class LocationEngine {
    * @param priority One of the {@link LocationEnginePriority}s listed.
    * @since 2.0.0
    */
-  public void setPriority(@IntRange(from = 0, to = 3) int priority) {
+  public void setPriority(@LocationEnginePriority.PowerMode int priority) {
     this.priority = priority;
   }
 

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/LocationEnginePriority.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/LocationEnginePriority.java
@@ -1,5 +1,10 @@
 package com.mapbox.services.android.core.location;
 
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Same priorities GMS and Lost support:
  * <p>
@@ -11,4 +16,9 @@ public class LocationEnginePriority {
   public static final int LOW_POWER = 1;
   public static final int BALANCED_POWER_ACCURACY = 2;
   public static final int HIGH_ACCURACY = 3;
+
+  @IntDef({NO_POWER, LOW_POWER, BALANCED_POWER_ACCURACY, HIGH_ACCURACY})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface PowerMode {
+  }
 }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -12,6 +12,8 @@ import android.net.NetworkInfo;
 import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
 
+import com.mapbox.services.android.core.location.LocationEnginePriority;
+
 import java.util.List;
 
 import okhttp3.Callback;
@@ -93,6 +95,12 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
     if (serviceBound) {
       SessionIdentifier sessionIdentifier = new SessionIdentifier(hour);
       telemetryService.updateSessionIdentifier(sessionIdentifier);
+    }
+  }
+
+  public void updateLocationPriority(@LocationEnginePriority.PowerMode int locationPriority) {
+    if (serviceBound) {
+      telemetryService.updateLocationPriority(locationPriority);
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryService.java
@@ -25,6 +25,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   private boolean isLocationReceiverRegistered = false;
   private boolean isTelemetryReceiverRegistered = false;
   private LocationEngine locationEngine = null;
+  private @LocationEnginePriority.PowerMode int locationPriority = LocationEnginePriority.HIGH_ACCURACY;
 
   @Nullable
   @Override
@@ -111,8 +112,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   }
 
   private void setupLocationEngine() {
-    // TODO Expose a way to change the priority
-    locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+    locationEngine.setPriority(locationPriority);
     locationEngine.addLocationEngineListener(this);
   }
 
@@ -165,6 +165,16 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   class TelemetryBinder extends Binder {
     TelemetryService obtainService() {
       return TelemetryService.this;
+    }
+  }
+
+  public void updateLocationPriority(@LocationEnginePriority.PowerMode int priority) {
+    locationPriority = priority;
+
+    if (locationEngine != null) {
+      disconnectLocationEngine();
+      locationEngine.setPriority(locationPriority);
+      locationEngine.activate();
     }
   }
 }


### PR DESCRIPTION
Location Engine is currently hardcoded to `LocationEnginePriority.HIGH_ACCURACY`. Migrate to allowing developer to edit location engine priority to match their needs.