### PR TITLE
Debug Logging API

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -34,7 +34,6 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
   private boolean isTelemetryEnabled = false;
   private boolean isOpted = false;
   private boolean serviceBound = false;
-  private boolean debugLoggingEnabled = false;
 
   public MapboxTelemetry(Context context, String accessToken, String userAgent, Callback httpCallback) {
     this.context = context;
@@ -97,15 +96,9 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
     }
   }
 
-  public boolean isDebugLoggingEnabled() {
-    return debugLoggingEnabled;
-  }
-
-  public void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
-    this.debugLoggingEnabled = debugLoggingEnabled;
-
+  public void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
     if (telemetryClient != null) {
-      telemetryClient.setDebugLoggingEnabled(debugLoggingEnabled);
+      telemetryClient.updateDebugLoggingEnabled(debugLoggingEnabled);
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -124,12 +124,13 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
     }
   }
 
+
   public void updateDebugLoggingEnabled(boolean isDebugLoggingEnabled) {
     if (telemetryClient != null) {
       telemetryClient.updateDebugLoggingEnabled(isDebugLoggingEnabled);
     }
   }
-  
+
   public void updateUserAgent(String userAgent) {
     if (isUserAgentValid(userAgent)) {
       telemetryClient.updateUserAgent(TelemetryUtils.createFullUserAgent(userAgent, context));

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -143,7 +143,6 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
   private TelemetryClient createTelemetryClient(String accessToken, String userAgent) {
     TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
       .environment(Environment.STAGING)
-      .debugLoggingEnabled(false)
       .build();
     telemetryClient = new TelemetryClient(accessToken, userAgent, telemetryClientSettings, new Logger());
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -96,9 +96,9 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
     }
   }
 
-  public void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
+  public void updateDebugLoggingEnabled(boolean isDebugLoggingEnabled) {
     if (telemetryClient != null) {
-      telemetryClient.updateDebugLoggingEnabled(debugLoggingEnabled);
+      telemetryClient.updateDebugLoggingEnabled(isDebugLoggingEnabled);
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -34,6 +34,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
   private boolean isTelemetryEnabled = false;
   private boolean isOpted = false;
   private boolean serviceBound = false;
+  private boolean debugLoggingEnabled = false;
 
   public MapboxTelemetry(Context context, String accessToken, String userAgent, Callback httpCallback) {
     this.context = context;
@@ -93,6 +94,18 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
     if (serviceBound) {
       SessionIdentifier sessionIdentifier = new SessionIdentifier(hour);
       telemetryService.updateSessionIdentifier(sessionIdentifier);
+    }
+  }
+
+  public boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
+  }
+
+  public void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
+
+    if (telemetryClient != null) {
+      telemetryClient.setDebugLoggingEnabled(debugLoggingEnabled);
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -143,6 +143,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback {
   private TelemetryClient createTelemetryClient(String accessToken, String userAgent) {
     TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
       .environment(Environment.STAGING)
+      .debugLoggingEnabled(false)
       .build();
     telemetryClient = new TelemetryClient(accessToken, userAgent, telemetryClientSettings, new Logger());
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -24,9 +24,8 @@ public class TelemetryClient {
 
   private String accessToken = null;
   private String userAgent = null;
-  private final TelemetryClientSettings setting;
+  private TelemetryClientSettings setting;
   private final Logger logger;
-  private boolean debugLoggingEnabled = false;
 
   // TODO Access can be package-private, remove public modifier after removing instances from the test app
   public TelemetryClient(String accessToken, String userAgent, TelemetryClientSettings setting, Logger logger) {
@@ -50,7 +49,7 @@ public class TelemetryClient {
   }
 
   void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
-    setting.updateDebugLoggingEnabled(debugLoggingEnabled);
+    setting = setting.toBuilder().debugLoggingEnabled(debugLoggingEnabled).build();
   }
 
   private void sendBatch(List<Event> batch, Callback callback) {

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -49,12 +49,8 @@ public class TelemetryClient {
     sendBatch(oneEvent, callback);
   }
 
-  void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
-    this.debugLoggingEnabled = debugLoggingEnabled;
-  }
-
-  private boolean isDebugLoggingEnabled() {
-    return debugLoggingEnabled;
+  void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    setting.updateDebugLoggingEnabled(debugLoggingEnabled);
   }
 
   private void sendBatch(List<Event> batch, Callback callback) {
@@ -66,7 +62,7 @@ public class TelemetryClient {
       .addQueryParameter(ACCESS_TOKEN_QUERY_PARAMETER, accessToken).build();
 
     // Extra debug in staging mode or debug mode
-    if (isDebugLoggingEnabled() || setting.getEnvironment().equals(Environment.STAGING)) {
+    if (isExtraDebuggingNeeded()) {
       logger.debug(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with "
         + "payload: %s", url, batch.size(), userAgent, payload));
     }
@@ -79,5 +75,9 @@ public class TelemetryClient {
 
     OkHttpClient client = setting.getClient();
     client.newCall(request).enqueue(callback);
+  }
+
+  private boolean isExtraDebuggingNeeded() {
+    return setting.isDebugLoggingEnabled() || setting.getEnvironment().equals(Environment.STAGING);
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -21,6 +21,8 @@ public class TelemetryClient {
   private static final String EVENTS_ENDPOINT = "/events/v2";
   private static final String USER_AGENT_REQUEST_HEADER = "User-Agent";
   private static final String ACCESS_TOKEN_QUERY_PARAMETER = "access_token";
+  private static final String EXTRA_DEBUGGING_LOG = "Sending POST to %s with %d event(s) (user agent: %s) "
+    + "with payload: %s";
 
   private String accessToken = null;
   private String userAgent = null;
@@ -61,8 +63,7 @@ public class TelemetryClient {
       .addQueryParameter(ACCESS_TOKEN_QUERY_PARAMETER, accessToken).build();
 
     if (isExtraDebuggingNeeded()) {
-      logger.debug(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with "
-        + "payload: %s", url, batch.size(), userAgent, payload));
+      logger.debug(LOG_TAG, String.format(EXTRA_DEBUGGING_LOG, url, batch.size(), userAgent, payload));
     }
 
     Request request = new Request.Builder()

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -84,7 +84,7 @@ class TelemetryClient {
   private boolean isExtraDebuggingNeeded() {
     return setting.isDebugLoggingEnabled() || setting.getEnvironment().equals(Environment.STAGING);
   }
-  
+
   private GsonBuilder configureGsonBuilder() {
     GsonBuilder gsonBuilder = new GsonBuilder();
     JsonSerializer<NavigationArriveEvent> arriveSerializer = new ArriveEventSerializer();

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -61,7 +61,6 @@ public class TelemetryClient {
     HttpUrl url = baseUrl.newBuilder(EVENTS_ENDPOINT)
       .addQueryParameter(ACCESS_TOKEN_QUERY_PARAMETER, accessToken).build();
 
-    // Extra debug in staging mode or debug mode
     if (isExtraDebuggingNeeded()) {
       logger.debug(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with "
         + "payload: %s", url, batch.size(), userAgent, payload));

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -26,6 +26,7 @@ public class TelemetryClient {
   private String userAgent = null;
   private final TelemetryClientSettings setting;
   private final Logger logger;
+  private boolean debugLoggingEnabled = false;
 
   // TODO Access can be package-private, remove public modifier after removing instances from the test app
   public TelemetryClient(String accessToken, String userAgent, TelemetryClientSettings setting, Logger logger) {
@@ -48,6 +49,14 @@ public class TelemetryClient {
     sendBatch(oneEvent, callback);
   }
 
+  void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
+  }
+
+  private boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
+  }
+
   private void sendBatch(List<Event> batch, Callback callback) {
     String payload = new Gson().toJson(batch);
     RequestBody body = RequestBody.create(JSON, payload);
@@ -56,8 +65,8 @@ public class TelemetryClient {
     HttpUrl url = baseUrl.newBuilder(EVENTS_ENDPOINT)
       .addQueryParameter(ACCESS_TOKEN_QUERY_PARAMETER, accessToken).build();
 
-    // Extra debug in staging mode
-    if (setting.getEnvironment().equals(Environment.STAGING)) {
+    // Extra debug in staging mode or debug mode
+    if (isDebugLoggingEnabled() || setting.getEnvironment().equals(Environment.STAGING)) {
       logger.debug(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with "
         + "payload: %s", url, batch.size(), userAgent, payload));
     }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
@@ -29,7 +29,7 @@ public class TelemetryClientSettings {
   private final HttpUrl baseUrl;
   private final SSLSocketFactory sslSocketFactory;
   private final X509TrustManager x509TrustManager;
-  private boolean debugLoggingEnabled = false;
+  private boolean debugLoggingEnabled;
 
   private TelemetryClientSettings(Builder builder) {
     this.environment = builder.environment;
@@ -37,6 +37,7 @@ public class TelemetryClientSettings {
     this.baseUrl = builder.baseUrl;
     this.sslSocketFactory = builder.sslSocketFactory;
     this.x509TrustManager = builder.x509TrustManager;
+    this.debugLoggingEnabled = builder.debugLoggingEnabled;
   }
 
   Environment getEnvironment() {
@@ -49,6 +50,14 @@ public class TelemetryClientSettings {
 
   HttpUrl getBaseUrl() {
     return baseUrl;
+  }
+
+  boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
+  }
+
+  void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
   }
 
   private OkHttpClient configureHttpClient() {
@@ -75,6 +84,7 @@ public class TelemetryClientSettings {
     HttpUrl baseUrl = null;
     SSLSocketFactory sslSocketFactory = null;
     X509TrustManager x509TrustManager = null;
+    boolean debugLoggingEnabled;
 
     public Builder() {
     }
@@ -108,6 +118,11 @@ public class TelemetryClientSettings {
       return this;
     }
 
+    public Builder debugLoggingEnabled(Boolean debugLoggingEnabled) {
+      this.debugLoggingEnabled = debugLoggingEnabled;
+      return this;
+    }
+
     public TelemetryClientSettings build() {
       if (baseUrl == null) {
         this.baseUrl = configureUrlHostname();
@@ -121,13 +136,5 @@ public class TelemetryClientSettings {
       builder.host(eventsHost);
       return builder.build();
     }
-  }
-
-  void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
-    this.debugLoggingEnabled = debugLoggingEnabled;
-  }
-
-  boolean isDebugLoggingEnabled() {
-    return debugLoggingEnabled;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
@@ -56,10 +56,6 @@ public class TelemetryClientSettings {
     return debugLoggingEnabled;
   }
 
-  void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
-    this.debugLoggingEnabled = debugLoggingEnabled;
-  }
-
   private OkHttpClient configureHttpClient() {
     CertificatePinnerFactory factory = new CertificatePinnerFactory();
     OkHttpClient.Builder builder = client.newBuilder()
@@ -78,13 +74,17 @@ public class TelemetryClientSettings {
     return sslSocketFactory != null && x509TrustManager != null;
   }
 
+  Builder toBuilder() {
+    return toBuilder();
+  }
+
   public static final class Builder {
     Environment environment = Environment.COM;
     OkHttpClient client = new OkHttpClient();
     HttpUrl baseUrl = null;
     SSLSocketFactory sslSocketFactory = null;
     X509TrustManager x509TrustManager = null;
-    boolean debugLoggingEnabled;
+    boolean debugLoggingEnabled = false;
 
     public Builder() {
     }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
@@ -12,7 +12,7 @@ import okhttp3.ConnectionSpec;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
-public abstract class TelemetryClientSettings {
+public class TelemetryClientSettings {
   private static final String STAGING_EVENTS_HOST = "api-events-staging.tilestream.net";
   private static final String COM_EVENTS_HOST = "events.mapbox.com";
   private static final String CHINA_EVENTS_HOST = "events.mapbox.cn";
@@ -31,7 +31,7 @@ public abstract class TelemetryClientSettings {
   private final X509TrustManager x509TrustManager;
   private boolean debugLoggingEnabled;
 
-  private TelemetryClientSettings(Builder builder) {
+  TelemetryClientSettings(Builder builder) {
     this.environment = builder.environment;
     this.client = builder.client;
     this.baseUrl = builder.baseUrl;
@@ -74,7 +74,15 @@ public abstract class TelemetryClientSettings {
     return sslSocketFactory != null && x509TrustManager != null;
   }
 
-  abstract Builder toBuilder();
+  Builder toBuilder() {
+    return new Builder()
+      .environment(environment)
+      .client(client)
+      .baseUrl(baseUrl)
+      .sslSocketFactory(sslSocketFactory)
+      .x509TrustManager(x509TrustManager)
+      .debugLoggingEnabled(debugLoggingEnabled);
+  }
 
   public static final class Builder {
     Environment environment = Environment.COM;
@@ -125,12 +133,7 @@ public abstract class TelemetryClientSettings {
       if (baseUrl == null) {
         this.baseUrl = configureUrlHostname();
       }
-      return new TelemetryClientSettings(this) {
-        @Override
-        Builder toBuilder() {
-          return null;
-        }
-      };
+      return new TelemetryClientSettings(this);
     }
 
     private HttpUrl configureUrlHostname() {

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
@@ -29,6 +29,7 @@ public class TelemetryClientSettings {
   private final HttpUrl baseUrl;
   private final SSLSocketFactory sslSocketFactory;
   private final X509TrustManager x509TrustManager;
+  private boolean debugLoggingEnabled = false;
 
   private TelemetryClientSettings(Builder builder) {
     this.environment = builder.environment;
@@ -120,5 +121,13 @@ public class TelemetryClientSettings {
       builder.host(eventsHost);
       return builder.build();
     }
+  }
+
+  void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
+  }
+
+  boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClientSettings.java
@@ -12,7 +12,7 @@ import okhttp3.ConnectionSpec;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
-public class TelemetryClientSettings {
+public abstract class TelemetryClientSettings {
   private static final String STAGING_EVENTS_HOST = "api-events-staging.tilestream.net";
   private static final String COM_EVENTS_HOST = "events.mapbox.com";
   private static final String CHINA_EVENTS_HOST = "events.mapbox.cn";
@@ -74,9 +74,7 @@ public class TelemetryClientSettings {
     return sslSocketFactory != null && x509TrustManager != null;
   }
 
-  Builder toBuilder() {
-    return toBuilder();
-  }
+  abstract Builder toBuilder();
 
   public static final class Builder {
     Environment environment = Environment.COM;
@@ -118,7 +116,7 @@ public class TelemetryClientSettings {
       return this;
     }
 
-    public Builder debugLoggingEnabled(Boolean debugLoggingEnabled) {
+    public Builder debugLoggingEnabled(boolean debugLoggingEnabled) {
       this.debugLoggingEnabled = debugLoggingEnabled;
       return this;
     }
@@ -127,7 +125,12 @@ public class TelemetryClientSettings {
       if (baseUrl == null) {
         this.baseUrl = configureUrlHostname();
       }
-      return new TelemetryClientSettings(this);
+      return new TelemetryClientSettings(this) {
+        @Override
+        Builder toBuilder() {
+          return null;
+        }
+      };
     }
 
     private HttpUrl configureUrlHostname() {


### PR DESCRIPTION
Enables extra logging of telemetry request when activated. This is defaulted to off, but can be activated through a public api.