### PR TITLE
Remove send a single event method and use sendEvents instead

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryClient.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSerializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -45,13 +44,6 @@ class TelemetryClient {
     ArrayList<Event> batch = new ArrayList<>();
     batch.addAll(events);
     sendBatch(batch, callback);
-  }
-
-  // TODO Remove send a single event method. Use sendEvents instead
-  void sendEvent(Event event, Callback callback) throws IOException {
-    ArrayList<Event> oneEvent = new ArrayList<>();
-    oneEvent.add(event);
-    sendBatch(oneEvent, callback);
   }
 
   void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import okhttp3.Callback;
 
 import static org.mockito.Mockito.mock;
@@ -13,15 +15,16 @@ public class TelemetryClientAppUserTurnstileEventTest extends MockWebServerTest 
 
   @Test
   public void sendsTheCorrectBodyPostingAppUserTurnstileEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(theAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(theAppUserTurnstile, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theAppUserTurnstile);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theAppUserTurnstile.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientLocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientLocationEventTest.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import okhttp3.Callback;
 
 import static org.mockito.Mockito.mock;
@@ -13,16 +15,17 @@ public class TelemetryClientLocationEventTest extends MockWebServerTest {
 
   @Test
   public void sendsTheCorrectBodyPostingLocationEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     double aLatitude = 40.416775;
     double aLongitude = -3.703790;
-    Event theLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude);
+    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude);
+    List<Event> theLocationEvent = obtainEvents(aLocationEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(theLocationEvent, mockedCallback);
+    telemetryClient.sendEvents(theLocationEvent, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theLocationEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theLocationEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientMapEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientMapEventsTest.java
@@ -46,60 +46,63 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
 
   @Test
   public void sendsTheCorrectBodyPostingMapLoadEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type load = Event.Type.MAP_LOAD;
-    Event loadEvent = obtainMapEvent(load);
+    Event aLoadEvent = obtainMapEvent(load);
+    List<Event> theLoadEvent = obtainEvents(aLoadEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(loadEvent, mockedCallback);
+    telemetryClient.sendEvents(theLoadEvent, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), loadEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theLoadEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingMapClickEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type click = Event.Type.MAP_CLICK;
-    Event clickEvent = obtainMapEvent(click);
+    Event aClickEvent = obtainMapEvent(click);
+    List<Event> theClickEvent = obtainEvents(aClickEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(clickEvent, mockedCallback);
+    telemetryClient.sendEvents(theClickEvent, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), clickEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theClickEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingMapDragendEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type dragend = Event.Type.MAP_DRAGEND;
-    Event dragendEvent = obtainMapEvent(dragend);
+    Event aDragendEvent = obtainMapEvent(dragend);
+    List<Event> theDragendEvent = obtainEvents(aDragendEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(dragendEvent, mockedCallback);
+    telemetryClient.sendEvents(theDragendEvent, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), dragendEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theDragendEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingMultipleEvents() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type load = Event.Type.MAP_LOAD;
     Event loadEvent = obtainMapEvent(load);
     Event.Type click = Event.Type.MAP_CLICK;
     Event clickEvent = obtainMapEvent(click);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
-    List<Event> events = addEvents(loadEvent, clickEvent);
+    List<Event> events = obtainEvents(loadEvent, clickEvent);
 
     telemetryClient.sendEvents(events, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), loadEvent, clickEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), events.get(0), events.get(1));
     assertRequestBodyEquals(expectedRequestBody);
   }
 

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientNavigationEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientNavigationEventsTest.java
@@ -103,124 +103,131 @@ public class TelemetryClientNavigationEventsTest extends MockWebServerTest {
 
   @Test
   public void sendsTheCorrectBodyPostingAppUserTurnstileEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(theAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(theAppUserTurnstile, mockedCallback);
 
-    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theAppUserTurnstile);
+    String expectedRequestBody = obtainExpectedRequestBody(new GsonBuilder(), theAppUserTurnstile.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationArriveEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type arrive = Event.Type.NAV_ARRIVE;
-    Event arriveEvent = obtainNavigationEvent(arrive);
+    Event anArriveEvent = obtainNavigationEvent(arrive);
+    List<Event> theArriveEvent = obtainEvents(anArriveEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(arriveEvent, mockedCallback);
+    telemetryClient.sendEvents(theArriveEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(arrive, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, arriveEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theArriveEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationDepartEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type depart = Event.Type.NAV_DEPART;
-    Event departEvent = obtainNavigationEvent(depart);
+    Event aDepartEvent = obtainNavigationEvent(depart);
+    List<Event> theDepartEvent = obtainEvents(aDepartEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(departEvent, mockedCallback);
+    telemetryClient.sendEvents(theDepartEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(depart, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, departEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theDepartEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationCancelEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type cancel = Event.Type.NAV_CANCEL;
-    Event cancelEvent = obtainNavigationEvent(cancel);
+    Event aCancelEvent = obtainNavigationEvent(cancel);
+    List<Event> theCancelEvent = obtainEvents(aCancelEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(cancelEvent, mockedCallback);
+    telemetryClient.sendEvents(theCancelEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(cancel, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, cancelEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theCancelEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationFeedbackEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type feedback = Event.Type.NAV_FEEDBACK;
-    Event feedbackEvent = obtainNavigationEvent(feedback);
+    Event aFeedbackEvent = obtainNavigationEvent(feedback);
+    List<Event> theFeedbackEvent = obtainEvents(aFeedbackEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(feedbackEvent, mockedCallback);
+    telemetryClient.sendEvents(theFeedbackEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(feedback, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, feedbackEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theFeedbackEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationRerouteEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type reroute = Event.Type.NAV_REROUTE;
-    Event rerouteEvent = obtainNavigationEvent(reroute);
+    Event aRerouteEvent = obtainNavigationEvent(reroute);
+    List<Event> theRerouteEvent = obtainEvents(aRerouteEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(rerouteEvent, mockedCallback);
+    telemetryClient.sendEvents(theRerouteEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(reroute, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, rerouteEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theRerouteEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingNavigationFasterRouteEvent() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type fasterRoute = Event.Type.NAV_FASTER_ROUTE;
-    Event fasterRouteEvent = obtainNavigationEvent(fasterRoute);
+    Event aFasterRouteEvent = obtainNavigationEvent(fasterRoute);
+    List<Event> theFasterRouteEvent = obtainEvents(aFasterRouteEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(fasterRouteEvent, mockedCallback);
+    telemetryClient.sendEvents(theFasterRouteEvent, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(fasterRoute, new GsonBuilder());
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, fasterRouteEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, theFasterRouteEvent.get(0));
     assertRequestBodyEquals(expectedRequestBody);
   }
 
   @Test
   public void sendsTheCorrectBodyPostingMultipleEvents() throws Exception {
-    TelemetryClient telemetryClient = obtainDefaultTelemetryClient();
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     Event.Type reroute = Event.Type.NAV_REROUTE;
     Event rerouteEvent = obtainNavigationEvent(reroute);
     Event.Type fasterRoute = Event.Type.NAV_FASTER_ROUTE;
     Event fasterRouteEvent = obtainNavigationEvent(fasterRoute);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
-    List<Event> events = addEvents(rerouteEvent, fasterRouteEvent);
+    List<Event> events = obtainEvents(rerouteEvent, fasterRouteEvent);
 
     telemetryClient.sendEvents(events, mockedCallback);
 
     GsonBuilder gsonBuilder = configureTypeAdapter(reroute, new GsonBuilder());
     gsonBuilder = configureTypeAdapter(fasterRoute, gsonBuilder);
-    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, rerouteEvent, fasterRouteEvent);
+    String expectedRequestBody = obtainExpectedRequestBody(gsonBuilder, events.get(0), events.get(1));
     assertRequestBodyEquals(expectedRequestBody);
   }
 

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,186 +28,101 @@ public class TelemetryClientTest extends MockWebServerTest {
 
   @Test
   public void sendsContentTypeHeader() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event mockedAppUserTurnstile =
-      new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> mockedEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(mockedAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(mockedEvent, mockedCallback);
 
     assertRequestContainsHeader("Content-Type", "application/json; charset=utf-8");
   }
 
   @Test
   public void sendsContentEncodingHeader() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event mockedAppUserTurnstile =
-      new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> mockedEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(mockedAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(mockedEvent, mockedCallback);
 
     assertRequestContainsHeader("Content-Encoding", "gzip");
   }
 
   @Test
   public void sendsPostEventRequestWithTheCorrectAccessTokenParameter() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("theAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event mockedAppUserTurnstile =
-      new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("theAccessToken", "anyUserAgent");
+    List<Event> mockedEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(mockedAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(mockedEvent, mockedCallback);
 
     assertRequestContainsParameter("access_token", "theAccessToken");
   }
 
   @Test
   public void sendsUserAgentHeader() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "theUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event mockedAppUserTurnstile =
-      new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "theUserAgent");
+    List<Event> mockedEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(mockedAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(mockedEvent, mockedCallback);
 
     assertRequestContainsHeader("User-Agent", "theUserAgent");
   }
 
   @Test
   public void sendsPostEventRequestToTheCorrectEndpoint() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event mockedAppUserTurnstile =
-      new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> mockedEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(mockedAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(mockedEvent, mockedCallback);
 
     assertPostRequestSentTo("/events/v2");
   }
 
   @Test
   public void sendsTheCorrectBodyPostingAnEvent() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> theEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
 
-    telemetryClient.sendEvent(theAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(theEvent, mockedCallback);
 
     ArrayList<Event> events = new ArrayList<>(1);
-    events.add(theAppUserTurnstile);
+    events.add(theEvent.get(0));
     assertRequestBodyEquals(new Gson().toJson(events));
   }
 
   @Test
   public void receivesNoBodyPostingAnEventSuccessfully() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> theEvent = obtainAnEvent();
     Callback mockedCallback = mock(Callback.class);
     enqueueMockNoResponse(204);
 
-    telemetryClient.sendEvent(theAppUserTurnstile, mockedCallback);
+    telemetryClient.sendEvents(theEvent, mockedCallback);
 
     assertResponseBodyEquals(null);
   }
 
   @Test
   public void parsesUnauthorizedRequestResponseProperlyPostingAnEvent() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> theEvent = obtainAnEvent();
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicReference<String> bodyRef = new AtomicReference<>();
     final AtomicBoolean failureRef = new AtomicBoolean();
     Callback aCallback = provideACallback(latch, bodyRef, failureRef);
     enqueueMockResponse(401, "unauthorizedRequestResponse.json");
 
-    telemetryClient.sendEvent(theAppUserTurnstile, aCallback);
+    telemetryClient.sendEvents(theEvent, aCallback);
 
     latch.await();
     assertTelemetryResponseEquals(bodyRef.get(), "Unauthorized request, usually because of "
@@ -216,25 +132,15 @@ public class TelemetryClientTest extends MockWebServerTest {
 
   @Test
   public void parsesInvalidMessageBodyResponseProperlyPostingAnEvent() throws Exception {
-    HttpUrl localUrl = getBaseEndpointUrl();
-    SslClient sslClient = SslClient.localhost();
-    TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
-      .baseUrl(localUrl)
-      .sslSocketFactory(sslClient.socketFactory)
-      .x509TrustManager(sslClient.trustManager)
-      .build();
-    Logger mockedLogger = mock(Logger.class);
-    TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
+    List<Event> theEvent = obtainAnEvent();
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicReference<String> bodyRef = new AtomicReference<>();
     final AtomicBoolean failureRef = new AtomicBoolean();
     Callback aCallback = provideACallback(latch, bodyRef, failureRef);
     enqueueMockResponse(422, "invalidMessageBodyResponse.json");
 
-    telemetryClient.sendEvent(theAppUserTurnstile, aCallback);
+    telemetryClient.sendEvents(theEvent, aCallback);
 
     latch.await();
     assertTelemetryResponseEquals(bodyRef.get(), "Invalid message body, check the types and required properties of "
@@ -247,7 +153,7 @@ public class TelemetryClientTest extends MockWebServerTest {
     OkHttpClient localOkHttpClientWithShortTimeout = new OkHttpClient.Builder()
       .readTimeout(100, TimeUnit.MILLISECONDS)
       .build();
-    HttpUrl localUrl = getBaseEndpointUrl();
+    HttpUrl localUrl = obtainBaseEndpointUrl();
     SslClient sslClient = SslClient.localhost();
     TelemetryClientSettings telemetryClientSettings = new TelemetryClientSettings.Builder()
       .client(localOkHttpClientWithShortTimeout)
@@ -255,18 +161,16 @@ public class TelemetryClientTest extends MockWebServerTest {
       .sslSocketFactory(sslClient.socketFactory)
       .x509TrustManager(sslClient.trustManager)
       .build();
-    Logger mockedLogger = mock(Logger.class);
     TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
-      mockedLogger);
-    boolean indifferentTelemetryEnabled = false;
-    Event theAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+      mock(Logger.class));
+    List<Event> theEvent = obtainAnEvent();
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicReference<String> bodyRef = new AtomicReference<>();
     final AtomicBoolean failureRef = new AtomicBoolean();
     Callback aCallback = provideACallback(latch, bodyRef, failureRef);
     enqueueMockNoResponse(504);
 
-    telemetryClient.sendEvent(theAppUserTurnstile, aCallback);
+    telemetryClient.sendEvents(theEvent, aCallback);
 
     latch.await();
     assertTrue(failureRef.get());


### PR DESCRIPTION
- Removes `sendEvent` from `TelemetryClient` and fix all related tests.

👀 @electrostat @zugaldia 