### PR TITLE
Update CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: mbgl/83e63ed4e7:android-ndk-r16b
+      - image: mbgl/7d2403f42e:android-ndk-r16b
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -68,7 +68,7 @@ jobs:
       only:
       - master
     docker:
-      - image: mbgl/83e63ed4e7:android-ndk-r16b
+      - image: mbgl/7d2403f42e:android-ndk-r16b
     working_directory: ~/code
     environment:
       BUILDTYPE: Release


### PR DESCRIPTION
- Updates CI image to `mbgl/7d2403f42e:android-ndk-r16b` as in https://github.com/mapbox/mapbox-gl-native/pull/10695

👀 @electrostat @zugaldia 