### PR TITLE
Reorganize location-related manifest entries

### DIFF
--- a/liblocation/src/main/AndroidManifest.xml
+++ b/liblocation/src/main/AndroidManifest.xml
@@ -1,1 +1,6 @@
-<manifest package="com.mapbox.services.android.core.location"/>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mapbox.services.android.core.location">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+</manifest>

--- a/libtelemetry/src/main/AndroidManifest.xml
+++ b/libtelemetry/src/main/AndroidManifest.xml
@@ -3,10 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.mapbox.services.android.telemetry">
+
     <!--Needed: uses-sdk:minSdkVersion 14 cannot be smaller than version 15 declared in Lost-->
     <uses-sdk tools:overrideLibrary="com.mapzen.lost"/>
-
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application>
         <service android:name="com.mapbox.services.android.telemetry.TelemetryService"/>
     </application>


### PR DESCRIPTION
- Places `uses-permissions` within `liblocation`'s `AndroidManifest`

👀 @electrostat @zugaldia 


  