### PR TITLE
Remove map state object creation when building a map load event

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/Event.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/Event.java
@@ -12,7 +12,7 @@ public abstract class Event implements Parcelable {
     NAV_FEEDBACK, NAV_FASTER_ROUTE
   }
 
-  static EnumSet<Type> mapEventTypes = EnumSet.of(Type.MAP_LOAD, Type.MAP_CLICK, Type.MAP_DRAGEND);
+  static EnumSet<Type> mapGestureEventTypes = EnumSet.of(Type.MAP_CLICK, Type.MAP_DRAGEND);
   static EnumSet<Type> navigationEventTypes = EnumSet.of(Type.NAV_DEPART, Type.NAV_ARRIVE, Type.NAV_CANCEL,
     Type.NAV_REROUTE, Type.NAV_FEEDBACK, Type.NAV_FASTER_ROUTE);
 

--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapEventFactory.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/MapEventFactory.java
@@ -38,7 +38,8 @@ public class MapEventFactory {
   private static final int UNAVAILABLE_BATTERY_LEVEL = -1;
   private static final int DEFAULT_BATTERY_LEVEL = -1;
   private static final int NO_NETWORK = -1;
-  private static final String NOT_A_MAP_EVENT_TYPE = "Type must be a map event.";
+  private static final String NOT_A_LOAD_MAP_EVENT_TYPE = "Type must be a load map event.";
+  private static final String NOT_A_GESTURE_MAP_EVENT_TYPE = "Type must be a gesture map event.";
   private static final String MAP_STATE_ILLEGAL_NULL = "MapState cannot be null.";
   private static final Map<Integer, String> NETWORKS = new HashMap<Integer, String>() {
     {
@@ -67,14 +68,8 @@ public class MapEventFactory {
     }
   };
   private Context context = null;
-  private final Map<Event.Type, MapBuildEvent> BUILD_EVENT_MAP = new HashMap<Event.Type, MapBuildEvent>() {
+  private final Map<Event.Type, MapBuildEvent> BUILD_EVENT_MAP_GESTURE = new HashMap<Event.Type, MapBuildEvent>() {
     {
-      put(Event.Type.MAP_LOAD, new MapBuildEvent() {
-        @Override
-        public Event build(Context context, MapState mapState) {
-          return buildMapLoadEvent(context);
-        }
-      });
       put(Event.Type.MAP_CLICK, new MapBuildEvent() {
         @Override
         public Event build(Context context, MapState mapState) {
@@ -94,25 +89,14 @@ public class MapEventFactory {
     this.context = context;
   }
 
-  public Event createMapEvent(Event.Type type, MapState mapState) {
-    check(type, mapState);
-    return BUILD_EVENT_MAP.get(type).build(context, mapState);
+  public Event createMapLoadEvent(Event.Type type) {
+    checkLoad(type);
+    return buildMapLoadEvent(context);
   }
 
-  private MapLoadEvent buildMapLoadEvent(Context context) {
-    MapLoadEvent mapLoadEvent = new MapLoadEvent();
-
-    mapLoadEvent.setUserId(TelemetryUtils.obtainUniversalUniqueIdentifier());
-    mapLoadEvent.setOrientation(obtainOrientation(context));
-    mapLoadEvent.setAccessibilityFontScale(obtainAccessibilityFontScaleSize(context));
-    mapLoadEvent.setCarrier(obtainCellularCarrier(context));
-    mapLoadEvent.setCellularNetworkType(obtainCellularNetworkType(context));
-    mapLoadEvent.setResolution(obtainDisplayDensity(context));
-    mapLoadEvent.setBatteryLevel(obtainBatteryLevel());
-    mapLoadEvent.setPluggedIn(isPluggedIn());
-    mapLoadEvent.setWifi(obtainConnectedToWifi(context));
-
-    return mapLoadEvent;
+  public Event createMapGestureEvent(Event.Type type, MapState mapState) {
+    checkGesture(type, mapState);
+    return BUILD_EVENT_MAP_GESTURE.get(type).build(context, mapState);
   }
 
   private MapClickEvent buildMapClickEvent(Context context, MapState mapState) {
@@ -225,14 +209,36 @@ public class MapEventFactory {
     return false;
   }
 
-  private void check(Event.Type type, MapState mapState) {
-    checkMapEvent(type);
+  private MapLoadEvent buildMapLoadEvent(Context context) {
+    MapLoadEvent mapLoadEvent = new MapLoadEvent();
+
+    mapLoadEvent.setUserId(TelemetryUtils.obtainUniversalUniqueIdentifier());
+    mapLoadEvent.setOrientation(obtainOrientation(context));
+    mapLoadEvent.setAccessibilityFontScale(obtainAccessibilityFontScaleSize(context));
+    mapLoadEvent.setCarrier(obtainCellularCarrier(context));
+    mapLoadEvent.setCellularNetworkType(obtainCellularNetworkType(context));
+    mapLoadEvent.setResolution(obtainDisplayDensity(context));
+    mapLoadEvent.setBatteryLevel(obtainBatteryLevel());
+    mapLoadEvent.setPluggedIn(isPluggedIn());
+    mapLoadEvent.setWifi(obtainConnectedToWifi(context));
+
+    return mapLoadEvent;
+  }
+
+  private void checkLoad(Event.Type type) {
+    if (type != Event.Type.MAP_LOAD) {
+      throw new IllegalArgumentException(NOT_A_LOAD_MAP_EVENT_TYPE);
+    }
+  }
+
+  private void checkGesture(Event.Type type, MapState mapState) {
+    checkGestureMapEvent(type);
     isNotNull(mapState);
   }
 
-  private void checkMapEvent(Event.Type type) {
-    if (!Event.mapEventTypes.contains(type)) {
-      throw new IllegalArgumentException(NOT_A_MAP_EVENT_TYPE);
+  private void checkGestureMapEvent(Event.Type type) {
+    if (!Event.mapGestureEventTypes.contains(type)) {
+      throw new IllegalArgumentException(NOT_A_GESTURE_MAP_EVENT_TYPE);
     }
   }
 

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/MapEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/MapEventFactoryTest.java
@@ -18,9 +18,8 @@ public class MapEventFactoryTest {
   public void checksMapLoadEvent() throws Exception {
     Context mockedContext = obtainMockedContext();
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
-    MapState mockedMapState = mock(MapState.class);
 
-    Event mapLoadEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_LOAD, mockedMapState);
+    Event mapLoadEvent = aMapEventFactory.createMapLoadEvent(Event.Type.MAP_LOAD);
 
     assertTrue(mapLoadEvent instanceof MapLoadEvent);
   }
@@ -29,9 +28,8 @@ public class MapEventFactoryTest {
   public void checksLoadType() throws Exception {
     Context mockedContext = obtainMockedContext();
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
-    MapState mockedMapState = mock(MapState.class);
 
-    Event mapLoadEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_LOAD, mockedMapState);
+    Event mapLoadEvent = aMapEventFactory.createMapLoadEvent(Event.Type.MAP_LOAD);
 
     assertEquals(Event.Type.MAP_LOAD, mapLoadEvent.obtainType());
   }
@@ -42,7 +40,7 @@ public class MapEventFactoryTest {
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
     MapState mockedMapState = mock(MapState.class);
 
-    Event mapClickEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_CLICK, mockedMapState);
+    Event mapClickEvent = aMapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, mockedMapState);
 
     assertTrue(mapClickEvent instanceof MapClickEvent);
   }
@@ -53,7 +51,7 @@ public class MapEventFactoryTest {
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
     MapState mockedMapState = mock(MapState.class);
 
-    Event mapClickEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_CLICK, mockedMapState);
+    Event mapClickEvent = aMapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, mockedMapState);
 
     assertEquals(Event.Type.MAP_CLICK, mapClickEvent.obtainType());
   }
@@ -64,7 +62,7 @@ public class MapEventFactoryTest {
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
     MapState mockedMapState = mock(MapState.class);
 
-    Event mapDragendEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_DRAGEND, mockedMapState);
+    Event mapDragendEvent = aMapEventFactory.createMapGestureEvent(Event.Type.MAP_DRAGEND, mockedMapState);
 
     assertTrue(mapDragendEvent instanceof MapDragendEvent);
   }
@@ -75,19 +73,28 @@ public class MapEventFactoryTest {
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
     MapState mockedMapState = mock(MapState.class);
 
-    Event mapDragendEvent = aMapEventFactory.createMapEvent(Event.Type.MAP_DRAGEND, mockedMapState);
+    Event mapDragendEvent = aMapEventFactory.createMapGestureEvent(Event.Type.MAP_DRAGEND, mockedMapState);
 
     assertEquals(Event.Type.MAP_DRAGEND, mapDragendEvent.obtainType());
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void checksInvalidType() throws Exception {
+  public void checksLoadInvalidType() throws Exception {
     Context mockedContext = obtainMockedContext();
     MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
-    Event.Type notAMapType = Event.Type.NAV_ARRIVE;
+    Event.Type notALoadMapType = Event.Type.MAP_CLICK;
+
+    aMapEventFactory.createMapLoadEvent(notALoadMapType);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checksGestureInvalidType() throws Exception {
+    Context mockedContext = obtainMockedContext();
+    MapEventFactory aMapEventFactory = new MapEventFactory(mockedContext);
+    Event.Type notAGestureMapType = Event.Type.MAP_LOAD;
     MapState mockedMapState = mock(MapState.class);
 
-    aMapEventFactory.createMapEvent(notAMapType, mockedMapState);
+    aMapEventFactory.createMapGestureEvent(notAGestureMapType, mockedMapState);
   }
 
   @Test
@@ -97,7 +104,7 @@ public class MapEventFactoryTest {
     Event.Type aDragendMapEventType = Event.Type.MAP_DRAGEND;
     MapState aValidMapState = obtainAValidMapState();
 
-    Event aDragendMapEvent = aMapEventFactory.createMapEvent(aDragendMapEventType, aValidMapState);
+    Event aDragendMapEvent = aMapEventFactory.createMapGestureEvent(aDragendMapEventType, aValidMapState);
 
     assertTrue(aDragendMapEvent instanceof MapDragendEvent);
   }
@@ -109,7 +116,7 @@ public class MapEventFactoryTest {
     Event.Type aDragendMapEventType = Event.Type.MAP_DRAGEND;
     MapState nullMapState = null;
 
-    aMapEventFactory.createMapEvent(aDragendMapEventType, nullMapState);
+    aMapEventFactory.createMapGestureEvent(aDragendMapEventType, nullMapState);
   }
 
   private Context obtainMockedContext() {

--- a/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientMapEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/services/android/telemetry/TelemetryClientMapEventsTest.java
@@ -111,8 +111,7 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
     WindowManager mockedWindowManager = mock(WindowManager.class, RETURNS_DEEP_STUBS);
     when(mockedContext.getSystemService(Context.WINDOW_SERVICE)).thenReturn(mockedWindowManager);
     MapEventFactory mapEventFactory = new MapEventFactory(mockedContext);
-    MapState mapState = obtainDefaultMapState();
-    Event loadEvent = mapEventFactory.createMapEvent(Event.Type.MAP_LOAD, mapState);
+    Event loadEvent = mapEventFactory.createMapLoadEvent(Event.Type.MAP_LOAD);
     return loadEvent;
   }
 
@@ -134,7 +133,7 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
     Context mockedContext = obtainMockedContext();
     MapEventFactory mapEventFactory = new MapEventFactory(mockedContext);
     MapState mapState = obtainDefaultMapState();
-    Event clickEvent = mapEventFactory.createMapEvent(Event.Type.MAP_CLICK, mapState);
+    Event clickEvent = mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, mapState);
     return clickEvent;
   }
 
@@ -142,7 +141,7 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
     Context mockedContext = obtainMockedContext();
     MapEventFactory mapEventFactory = new MapEventFactory(mockedContext);
     MapState mapState = obtainDefaultMapState();
-    Event dragendEvent = mapEventFactory.createMapEvent(Event.Type.MAP_DRAGEND, mapState);
+    Event dragendEvent = mapEventFactory.createMapGestureEvent(Event.Type.MAP_DRAGEND, mapState);
     return dragendEvent;
   }
 


### PR DESCRIPTION
- Adds `createMapLoadEvent` method in order to remove the necessity of creating an empty `MapState` when creating `MAP_LOAD` events

👀 @electrostat @zugaldia 