### PR TITLE
MapboxTelemetry - Optional Callback

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryListener.java
+++ b/libtelemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryListener.java
@@ -1,0 +1,8 @@
+package com.mapbox.services.android.telemetry;
+
+public interface TelemetryListener {
+
+  void onHttpResponse(boolean successful, int code);
+
+  void onHttpFailure(String message);
+}

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapEventFactoryTest.java
@@ -7,8 +7,6 @@ import android.view.WindowManager;
 
 import org.junit.Test;
 
-import okhttp3.Callback;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -140,8 +138,7 @@ public class MapEventFactoryTest {
     MapboxTelemetry.applicationContext = mockedContext;
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";
-    Callback mockedHttpCallback = mock(Callback.class);
-    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent, mockedHttpCallback);
+    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent);
   }
 
   private MapState obtainAValidMapState() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -33,9 +33,8 @@ public class MapboxTelemetryTest {
     MapboxTelemetry.applicationContext = null;
     String anyAccessToken = "anyAccessToken";
     String anyUserAgent = "anyUserAgent";
-    Callback mockedHttpCallback = mock(Callback.class);
 
-    new MapboxTelemetry(null, anyAccessToken, anyUserAgent, mockedHttpCallback);
+    new MapboxTelemetry(null, anyAccessToken, anyUserAgent);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -45,9 +44,8 @@ public class MapboxTelemetryTest {
     when(nullApplicationContext.getApplicationContext()).thenReturn(null);
     String anyAccessToken = "anyAccessToken";
     String anyUserAgent = "anyUserAgent";
-    Callback mockedHttpCallback = mock(Callback.class);
 
-    new MapboxTelemetry(nullApplicationContext, anyAccessToken, anyUserAgent, mockedHttpCallback);
+    new MapboxTelemetry(nullApplicationContext, anyAccessToken, anyUserAgent);
   }
 
   @Test

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientMapEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientMapEventsTest.java
@@ -130,8 +130,7 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";
-    Callback mockedHttpCallback = mock(Callback.class);
-    new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent, mockedHttpCallback);
+    new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent);
   }
 
   private MapState obtainDefaultMapState() {


### PR DESCRIPTION
Make callback optional when creating MapboxTelemetry, so developer does not need to subscribe to the TelemetryClient Callback.