### PR TITLE
Ensure that Location Engine priority is set in the correct range 

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
@@ -10,6 +10,8 @@ import android.text.TextUtils;
 import com.mapbox.android.core.permissions.PermissionsManager;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A location engine that uses core android.location and has no external dependencies
@@ -26,6 +28,35 @@ class AndroidLocationEngine extends LocationEngine implements LocationListener {
   private WeakReference<Context> context;
   private LocationManager locationManager;
   private String currentProvider = null;
+  private final Map<LocationEnginePriority, UpdateAndroidProvider> CURRENT_PROVIDER = new
+    HashMap<LocationEnginePriority, UpdateAndroidProvider>() {
+      {
+        put(LocationEnginePriority.NO_POWER, new UpdateAndroidProvider() {
+          @Override
+          public void update() {
+            currentProvider = LocationManager.PASSIVE_PROVIDER;
+          }
+        });
+        put(LocationEnginePriority.LOW_POWER, new UpdateAndroidProvider() {
+          @Override
+          public void update() {
+            currentProvider = LocationManager.NETWORK_PROVIDER;
+          }
+        });
+        put(LocationEnginePriority.BALANCED_POWER_ACCURACY, new UpdateAndroidProvider() {
+          @Override
+          public void update() {
+            currentProvider = LocationManager.NETWORK_PROVIDER;
+          }
+        });
+        put(LocationEnginePriority.HIGH_ACCURACY, new UpdateAndroidProvider() {
+          @Override
+          public void update() {
+            currentProvider = LocationManager.GPS_PROVIDER;
+          }
+        });
+      }
+    };
 
   private AndroidLocationEngine(Context context) {
     super();
@@ -80,7 +111,7 @@ class AndroidLocationEngine extends LocationEngine implements LocationListener {
   }
 
   @Override
-  public void setPriority(@LocationEnginePriority.PowerMode int priority) {
+  public void setPriority(LocationEnginePriority priority) {
     super.setPriority(priority);
     updateCurrentProvider();
   }
@@ -131,14 +162,6 @@ class AndroidLocationEngine extends LocationEngine implements LocationListener {
 
   private void updateCurrentProvider() {
     // We might want to explore android.location.Criteria here.
-    if (priority == LocationEnginePriority.NO_POWER) {
-      currentProvider = LocationManager.PASSIVE_PROVIDER;
-    } else if (priority == LocationEnginePriority.LOW_POWER) {
-      currentProvider = LocationManager.NETWORK_PROVIDER;
-    } else if (priority == LocationEnginePriority.BALANCED_POWER_ACCURACY) {
-      currentProvider = LocationManager.NETWORK_PROVIDER;
-    } else if (priority == LocationEnginePriority.HIGH_ACCURACY) {
-      currentProvider = LocationManager.GPS_PROVIDER;
-    }
+    CURRENT_PROVIDER.get(priority).update();
   }
 }

--- a/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 
 import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.services.android.core.location.UpdateAndroidProvider;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;

--- a/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
@@ -13,6 +13,8 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Sample LocationEngine using Google Play Services
@@ -24,6 +26,35 @@ class GoogleLocationEngine extends LocationEngine implements
 
   private WeakReference<Context> context;
   private GoogleApiClient googleApiClient;
+  private final Map<LocationEnginePriority, UpdateGoogleRequestPriority> REQUEST_PRIORITY = new
+    HashMap<LocationEnginePriority, UpdateGoogleRequestPriority>() {
+      {
+        put(LocationEnginePriority.NO_POWER, new UpdateGoogleRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_NO_POWER);
+          }
+        });
+        put(LocationEnginePriority.LOW_POWER, new UpdateGoogleRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
+          }
+        });
+        put(LocationEnginePriority.BALANCED_POWER_ACCURACY, new UpdateGoogleRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+          }
+        });
+        put(LocationEnginePriority.HIGH_ACCURACY, new UpdateGoogleRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+          }
+        });
+      }
+    };
 
   private GoogleLocationEngine(Context context) {
     super();
@@ -99,15 +130,7 @@ class GoogleLocationEngine extends LocationEngine implements
       request.setSmallestDisplacement(smallestDisplacement);
     }
 
-    if (priority == LocationEnginePriority.NO_POWER) {
-      request.setPriority(LocationRequest.PRIORITY_NO_POWER);
-    } else if (priority == LocationEnginePriority.LOW_POWER) {
-      request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
-    } else if (priority == LocationEnginePriority.BALANCED_POWER_ACCURACY) {
-      request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
-    } else if (priority == LocationEnginePriority.HIGH_ACCURACY) {
-      request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-    }
+    updateRequestPriority(request);
 
     if (googleApiClient.isConnected()) {
       //noinspection MissingPermission
@@ -142,5 +165,9 @@ class GoogleLocationEngine extends LocationEngine implements
         googleApiClient.connect();
       }
     }
+  }
+
+  private void updateRequestPriority(LocationRequest request) {
+    REQUEST_PRIORITY.get(priority).update(request);
   }
 }

--- a/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
@@ -11,6 +11,7 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
+import com.mapbox.services.android.core.location.UpdateGoogleRequestPriority;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;

--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
@@ -23,8 +23,7 @@ public abstract class LocationEngine {
 
   private static final int TWO_MINUTES = 1000 * 60 * 2;
 
-  @LocationEnginePriority.PowerMode
-  protected int priority;
+  protected LocationEnginePriority priority;
   protected Integer interval = 1000;
   protected Integer fastestInterval = 1000;
   protected Float smallestDisplacement = 3.0f;
@@ -103,8 +102,7 @@ public abstract class LocationEngine {
    * @return Integer representing one of the priorities listed inside the {@link LocationEnginePriority} file.
    * @since 2.0.0
    */
-  @LocationEnginePriority.PowerMode
-  public int getPriority() {
+  public LocationEnginePriority getPriority() {
     return priority;
   }
 
@@ -116,7 +114,7 @@ public abstract class LocationEngine {
    * @param priority One of the {@link LocationEnginePriority}s listed.
    * @since 2.0.0
    */
-  public void setPriority(@LocationEnginePriority.PowerMode int priority) {
+  public void setPriority(LocationEnginePriority priority) {
     this.priority = priority;
   }
 

--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEnginePriority.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEnginePriority.java
@@ -1,24 +1,8 @@
 package com.mapbox.android.core.location;
 
-import android.support.annotation.IntDef;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
-/**
- * Same priorities GMS and Lost support:
- * <p>
- * https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest
- * https://github.com/mapzen/lost/blob/master/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
- */
-public class LocationEnginePriority {
-  public static final int NO_POWER = 0;
-  public static final int LOW_POWER = 1;
-  public static final int BALANCED_POWER_ACCURACY = 2;
-  public static final int HIGH_ACCURACY = 3;
-
-  @IntDef({NO_POWER, LOW_POWER, BALANCED_POWER_ACCURACY, HIGH_ACCURACY})
-  @Retention(RetentionPolicy.SOURCE)
-  public @interface PowerMode {
-  }
+public enum LocationEnginePriority {
+  NO_POWER,
+  LOW_POWER,
+  BALANCED_POWER_ACCURACY,
+  HIGH_ACCURACY
 }

--- a/liblocation/src/main/java/com/mapbox/android/core/location/LostLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LostLocationEngine.java
@@ -5,6 +5,7 @@ import android.location.Location;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
+import com.mapbox.services.android.core.location.UpdateLostRequestPriority;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationServices;

--- a/liblocation/src/main/java/com/mapbox/android/core/location/LostLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LostLocationEngine.java
@@ -11,6 +11,8 @@ import com.mapzen.android.lost.api.LocationServices;
 import com.mapzen.android.lost.api.LostApiClient;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Sample LocationEngine using the Open Source Lost library
@@ -24,6 +26,35 @@ class LostLocationEngine extends LocationEngine implements
 
   private WeakReference<Context> context;
   private LostApiClient lostApiClient;
+  private final Map<LocationEnginePriority, UpdateLostRequestPriority> REQUEST_PRIORITY = new
+    HashMap<LocationEnginePriority, UpdateLostRequestPriority>() {
+      {
+        put(LocationEnginePriority.NO_POWER, new UpdateLostRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_NO_POWER);
+          }
+        });
+        put(LocationEnginePriority.LOW_POWER, new UpdateLostRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
+          }
+        });
+        put(LocationEnginePriority.BALANCED_POWER_ACCURACY, new UpdateLostRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+          }
+        });
+        put(LocationEnginePriority.HIGH_ACCURACY, new UpdateLostRequestPriority() {
+          @Override
+          public void update(LocationRequest request) {
+            request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+          }
+        });
+      }
+    };
 
   private LostLocationEngine(Context context) {
     super();
@@ -123,15 +154,7 @@ class LostLocationEngine extends LocationEngine implements
       request.setSmallestDisplacement(smallestDisplacement);
     }
 
-    if (priority == LocationEnginePriority.NO_POWER) {
-      request.setPriority(LocationRequest.PRIORITY_NO_POWER);
-    } else if (priority == LocationEnginePriority.LOW_POWER) {
-      request.setPriority(LocationRequest.PRIORITY_LOW_POWER);
-    } else if (priority == LocationEnginePriority.BALANCED_POWER_ACCURACY) {
-      request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
-    } else if (priority == LocationEnginePriority.HIGH_ACCURACY) {
-      request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-    }
+    updateRequestPriority(request);
 
     if (lostApiClient.isConnected()) {
       //noinspection MissingPermission
@@ -174,5 +197,9 @@ class LostLocationEngine extends LocationEngine implements
         lostApiClient.connect();
       }
     }
+  }
+
+  private void updateRequestPriority(LocationRequest request) {
+    REQUEST_PRIORITY.get(priority).update(request);
   }
 }

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateAndroidProvider.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateAndroidProvider.java
@@ -1,6 +1,6 @@
 package com.mapbox.services.android.core.location;
 
 
-interface UpdateAndroidProvider {
+public interface UpdateAndroidProvider {
   void update();
 }

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateAndroidProvider.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateAndroidProvider.java
@@ -1,0 +1,6 @@
+package com.mapbox.services.android.core.location;
+
+
+interface UpdateAndroidProvider {
+  void update();
+}

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateGoogleRequestPriority.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateGoogleRequestPriority.java
@@ -3,6 +3,6 @@ package com.mapbox.services.android.core.location;
 
 import com.google.android.gms.location.LocationRequest;
 
-interface UpdateGoogleRequestPriority {
+public interface UpdateGoogleRequestPriority {
   void update(LocationRequest request);
 }

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateGoogleRequestPriority.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateGoogleRequestPriority.java
@@ -1,0 +1,8 @@
+package com.mapbox.services.android.core.location;
+
+
+import com.google.android.gms.location.LocationRequest;
+
+interface UpdateGoogleRequestPriority {
+  void update(LocationRequest request);
+}

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateLostRequestPriority.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateLostRequestPriority.java
@@ -1,0 +1,8 @@
+package com.mapbox.services.android.core.location;
+
+
+import com.mapzen.android.lost.api.LocationRequest;
+
+interface UpdateLostRequestPriority {
+  void update(LocationRequest request);
+}

--- a/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateLostRequestPriority.java
+++ b/liblocation/src/main/java/com/mapbox/services/android/core/location/UpdateLostRequestPriority.java
@@ -3,6 +3,6 @@ package com.mapbox.services.android.core.location;
 
 import com.mapzen.android.lost.api.LocationRequest;
 
-interface UpdateLostRequestPriority {
+public interface UpdateLostRequestPriority {
   void update(LocationRequest request);
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -133,7 +133,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     }
   }
 
-  public void updateLocationPriority(@LocationEnginePriority.PowerMode int locationPriority) {
+  public void updateLocationPriority(LocationEnginePriority locationPriority) {
     if (serviceBound) {
       telemetryService.updateLocationPriority(locationPriority);
     }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -25,9 +25,8 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   private boolean isLocationReceiverRegistered = false;
   private boolean isTelemetryReceiverRegistered = false;
   private LocationEngine locationEngine = null;
-  @LocationEnginePriority.PowerMode
-  private int locationPriority = LocationEnginePriority.NO_POWER;
   private ServiceTaskCallback serviceTaskCallback = null;
+  private LocationEnginePriority locationPriority = LocationEnginePriority.NO_POWER;
 
   @Override
   public void onCreate() {
@@ -91,7 +90,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
     locationReceiver.updateSessionIdentifier(sessionIdentifier);
   }
 
-  public void updateLocationPriority(@LocationEnginePriority.PowerMode int priority) {
+  public void updateLocationPriority(LocationEnginePriority priority) {
     locationPriority = priority;
 
     if (locationEngine != null) {


### PR DESCRIPTION
Restrict value that can be set for location engine priority, utilizing enum paradigm.