### PR TITLE
Fix hardcoded event version in navigation general metadata

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
@@ -8,7 +8,6 @@ import java.util.Date;
 
 public class NavigationMetadata implements Parcelable {
   private static final String OPERATING_SYSTEM = "Android - " + Build.VERSION.RELEASE;
-  private static final int EVENT_VERSION = 3;
   private int absoluteDistanceToDestination;
   private Integer percentTimeInPortrait = null;
   private Integer percentTimeInForeground = null;
@@ -48,9 +47,9 @@ public class NavigationMetadata implements Parcelable {
   private String connectivity = null;
 
   public NavigationMetadata(Date startTimestamp, int distanceCompleted, int distanceRemaining, int durationRemaining,
-                            String sdKIdentifier, String sdkVersion, String sessionIdentifier, double lat, double lng,
-                            String geometry, String profile, boolean isSimulation, String device, String locationEngine,
-                            int absoluteDistanceToDestination) {
+                            String sdKIdentifier, String sdkVersion, int eventVersion, String sessionIdentifier,
+                            double lat, double lng, String geometry, String profile, boolean isSimulation,
+                            String device, String locationEngine, int absoluteDistanceToDestination) {
     this.startTimestamp = TelemetryUtils.generateCreateDateFormatted(startTimestamp);
     this.distanceCompleted = distanceCompleted;
     this.distanceRemaining = distanceRemaining;
@@ -58,7 +57,7 @@ public class NavigationMetadata implements Parcelable {
     this.operatingSystem = OPERATING_SYSTEM;
     this.sdKIdentifier = sdKIdentifier;
     this.sdkVersion = sdkVersion;
-    this.eventVersion = EVENT_VERSION;
+    this.eventVersion = eventVersion;
     this.sessionIdentifier = sessionIdentifier;
     this.lat = lat;
     this.lng = lng;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/NavigationEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/NavigationEventFactoryTest.java
@@ -178,7 +178,7 @@ public class NavigationEventFactoryTest {
 
   private NavigationState obtainAValidNavigationState() {
     NavigationMetadata metadata = new NavigationMetadata(new Date(), 13, 22, 180, "sdkIdentifier", "sdkVersion",
-      "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
+      3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
     return new NavigationState(metadata);
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SerializerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SerializerTest.java
@@ -19,7 +19,7 @@ public class SerializerTest {
   public void checkArriveSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
-      "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
+      3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));
     NavigationState navigationState = new NavigationState(metadata);
 
@@ -47,7 +47,7 @@ public class SerializerTest {
   public void checkDepartSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
-      "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
+      3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));
     NavigationState navigationState = new NavigationState(metadata);
 
@@ -77,7 +77,7 @@ public class SerializerTest {
   public void checkCancelSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
-      180, "sdkIdentifier", "sdkVersion", "sessionID", 10.5,
+      180, "sdkIdentifier", "sdkVersion", 3, "sessionID", 10.5,
       15.67, "geometry", "profile", false, "device",
       "LostLocationEngine", 50);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));
@@ -116,7 +116,7 @@ public class SerializerTest {
   public void checkFeedbackSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
-      "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
+      3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));
     FeedbackEventData navigationFeedbackData = new FeedbackEventData("userId", "general",
       "unknown", "audio");
@@ -162,7 +162,7 @@ public class SerializerTest {
   public void checkRerouteSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
-      180, "sdkIdent", "sdkversion", "sessionID", 10.5,
+      180, "sdkIdent", "sdkversion", 3, "sessionID", 10.5,
       15.67, "geometry", "profile", true, "device",
       "MockLocationEngine", 1300);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));
@@ -235,7 +235,7 @@ public class SerializerTest {
   public void checkFasterRouteSerializing() throws Exception {
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
-      180, "sdkIdent", "sdkversion", "sessionID", 10.5,
+      180, "sdkIdent", "sdkversion", 3, "sessionID", 10.5,
       15.67, "geometry", "profile", true, "device",
       "MockLocationEngine", 1300);
     metadata.setCreated(TelemetryUtils.generateCreateDateFormatted(testDate));

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
@@ -233,7 +233,7 @@ public class TelemetryClientNavigationEventsTest extends MockWebServerTest {
 
   private NavigationState obtainDefaultNavigationState(Date date) {
     NavigationMetadata metadata = new NavigationMetadata(date, 13, 22, 180, "sdkIdentifier", "sdkVersion",
-      "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
+      3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "device", "LostLocationEngine", 50);
     return new NavigationState(metadata);
   }
 


### PR DESCRIPTION
- Fixes hardcoded event version in navigation general metadata adding `eventVersion` parameter to `NavigationMetadata` constructor

👀 @electrostat @zugaldia @danesfeder @ericrwolfe 