### PR TITLE
Make userId required for AppUserTurnstile

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/AppUserTurnstile.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/AppUserTurnstile.java
@@ -28,10 +28,10 @@ public class AppUserTurnstile extends Event implements Parcelable {
   @SerializedName("operatingSystem")
   private String operatingSystem = null;
 
-  public AppUserTurnstile(boolean enabledTelemetry, String sdkIdentifier, String sdkVersion) {
+  public AppUserTurnstile(boolean enabledTelemetry, String sdkIdentifier, String sdkVersion, String userId) {
     this.event = APP_USER_TURNSTILE;
     this.created = TelemetryUtils.obtainCurrentDate();
-    this.userId = TelemetryUtils.obtainUniversalUniqueIdentifier();
+    this.userId = userId;
     this.enabledTelemetry = enabledTelemetry;
     this.sdkIdentifier = sdkIdentifier;
     this.sdkVersion = sdkVersion;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
@@ -23,6 +23,7 @@ public class AppUserTurnstileTest {
 
   private Event obtainAnAppUserTurnstileEvent() {
     boolean indifferentTelemetryEnabled = false;
-    return new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    return new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion",
+      "anyUserId");
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
@@ -132,7 +132,8 @@ class MockWebServerTest {
 
   List<Event> obtainAnEvent() {
     boolean indifferentTelemetryEnabled = false;
-    Event theEvent = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    Event theEvent = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+      "anySdkVersion", "anyUserId");
 
     return obtainEvents(theEvent);
   }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
@@ -17,7 +17,8 @@ public class TelemetryClientAppUserTurnstileEventTest extends MockWebServerTest 
   public void sendsTheCorrectBodyPostingAppUserTurnstileEvent() throws Exception {
     TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     boolean indifferentTelemetryEnabled = false;
-    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+      "anySdkVersion", "anyUserId");
     List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
@@ -105,7 +105,8 @@ public class TelemetryClientNavigationEventsTest extends MockWebServerTest {
   public void sendsTheCorrectBodyPostingAppUserTurnstileEvent() throws Exception {
     TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     boolean indifferentTelemetryEnabled = false;
-    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+      "anySdkVersion", "anyUserId");
     List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();
@@ -272,7 +273,7 @@ public class TelemetryClientNavigationEventsTest extends MockWebServerTest {
     NavigationEventFactory navigationEventFactory = new NavigationEventFactory();
     Date aDate = new Date();
     NavigationState navigationState = obtainDefaultNavigationState(aDate);
-    FeedbackEventData navigationFeedbackData = new FeedbackEventData("userId", "general",
+    FeedbackEventData navigationFeedbackData = new FeedbackEventData("anyUserId", "general",
       "unknown", "audio");
     FeedbackData feedbackData = obtainFeedbackData();
     NavigationVoiceData navigationVoiceData = new NavigationVoiceData("voiceInstruction",


### PR DESCRIPTION
Make userId required in constructor for AppUserTurnstile event. This allows clients to add in their own unique Mapbox vendor id.