### PR TITLE
Add non-null context required check

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -204,7 +204,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
   private void initializeContext(Context context) {
     if (applicationContext == null) {
-      if (context.getApplicationContext() != null) {
+      if (context != null && context.getApplicationContext() != null) {
         applicationContext = context.getApplicationContext();
       } else {
         throw new IllegalArgumentException(NON_NULL_APPLICATION_CONTEXT_REQUIRED);

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -28,6 +28,16 @@ import static org.mockito.Mockito.when;
 public class MapboxTelemetryTest {
 
   @Test(expected = IllegalArgumentException.class)
+  public void checksNonNullContextRequired() throws Exception {
+    MapboxTelemetry.applicationContext = null;
+    String anyAccessToken = "anyAccessToken";
+    String anyUserAgent = "anyUserAgent";
+    Callback mockedHttpCallback = mock(Callback.class);
+
+    new MapboxTelemetry(null, anyAccessToken, anyUserAgent, mockedHttpCallback);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void checksNonNullApplicationContextRequired() throws Exception {
     MapboxTelemetry.applicationContext = null;
     Context nullApplicationContext = mock(Context.class);


### PR DESCRIPTION
- Adds non-null `Context` required check when creating a `MapboxTelemetry` instance

👀 @electrostat @zugaldia 