### PR TITLE
Remove enabledTelemetry param

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/AppUserTurnstile.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/AppUserTurnstile.java
@@ -30,12 +30,12 @@ public class AppUserTurnstile extends Event implements Parcelable {
   @SerializedName("operatingSystem")
   private String operatingSystem = null;
 
-  public AppUserTurnstile(boolean enabledTelemetry, String sdkIdentifier, String sdkVersion) {
+  public AppUserTurnstile(String sdkIdentifier, String sdkVersion) {
     checkApplicationContext();
     this.event = APP_USER_TURNSTILE;
     this.created = TelemetryUtils.obtainCurrentDate();
     this.userId = TelemetryUtils.retrieveVendorId();
-    this.enabledTelemetry = enabledTelemetry;
+    this.enabledTelemetry = TelemetryUtils.retrieveEnabledTelemetry();
     this.sdkIdentifier = sdkIdentifier;
     this.sdkVersion = sdkVersion;
     this.model = Build.MODEL;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
@@ -15,8 +15,7 @@ public class AppUserTurnstileTest {
   public void checksMapboxTelemetryNotInitialized() throws Exception {
     MapboxTelemetry.applicationContext = null;
 
-    boolean indifferentTelemetryEnabled = false;
-    new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    new AppUserTurnstile("anySdkIdentifier", "anySdkVersion");
   }
 
   @Test
@@ -37,6 +36,6 @@ public class AppUserTurnstileTest {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     MapboxTelemetry.applicationContext = mockedContext;
     boolean indifferentTelemetryEnabled = false;
-    return new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier", "anySdkVersion");
+    return new AppUserTurnstile("anySdkIdentifier", "anySdkVersion");
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -181,7 +181,7 @@ public class MapboxTelemetryTest {
     MapboxTelemetry theMapboxTelemetry = new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent,
       mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       mockedLocalBroadcastManager, indifferentServiceBound);
-    Event whitelistedEvent = new AppUserTurnstile(true, "anySdkIdentifier", "anySdkVersion");
+    Event whitelistedEvent = new AppUserTurnstile("anySdkIdentifier", "anySdkVersion");
     ArgumentCaptor<List<Event>> eventsCaptor = ArgumentCaptor.forClass((Class) List.class);
     theMapboxTelemetry.enable();
 

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
@@ -131,8 +131,7 @@ class MockWebServerTest {
   }
 
   List<Event> obtainAnEvent() {
-    boolean indifferentTelemetryEnabled = false;
-    Event theEvent = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+    Event theEvent = new AppUserTurnstile("anySdkIdentifier",
       "anySdkVersion");
 
     return obtainEvents(theEvent);

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientAppUserTurnstileEventTest.java
@@ -21,8 +21,7 @@ public class TelemetryClientAppUserTurnstileEventTest extends MockWebServerTest 
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     MapboxTelemetry.applicationContext = mockedContext;
     TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
-    boolean indifferentTelemetryEnabled = false;
-    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+    Event anAppUserTurnstile = new AppUserTurnstile("anySdkIdentifier",
       "anySdkVersion");
     List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientNavigationEventsTest.java
@@ -108,8 +108,7 @@ public class TelemetryClientNavigationEventsTest extends MockWebServerTest {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     MapboxTelemetry.applicationContext = mockedContext;
     TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
-    boolean indifferentTelemetryEnabled = false;
-    Event anAppUserTurnstile = new AppUserTurnstile(indifferentTelemetryEnabled, "anySdkIdentifier",
+    Event anAppUserTurnstile = new AppUserTurnstile("anySdkIdentifier",
       "anySdkVersion");
     List<Event> theAppUserTurnstile = obtainEvents(anAppUserTurnstile);
     Callback mockedCallback = mock(Callback.class);


### PR DESCRIPTION
Remove enabledTelemetry param from AppUserTurnstile initialization and use previously created 'retrieveEnabledTelemetry' method in TelemetryUtils.