### PR TITLE
Updated license year to 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Mapbox
+Copyright (c) 2018 Mapbox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Cameron's license year update in the plugins repo (https://github.com/mapbox/mapbox-plugins-android/pull/249/files) spurred me to check our other repos. Kathleen confirmed that the years should be updated. This pr updates this repo's license. I've set an annual reminder on January 1st to check and update repos as needed.