### PR TITLE
Make Environment enum package private

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/Environment.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/Environment.java
@@ -1,7 +1,7 @@
 package com.mapbox.android.telemetry;
 
 
-public enum Environment {
+enum Environment {
   STAGING,
   COM,
   CHINA


### PR DESCRIPTION
- Makes `Environment` `enum` package private

👀 @electrostat @zugaldia 