### PR TITLE
Remove multiDexEnabled true line

### DIFF
--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -12,7 +12,6 @@ android {
         versionCode 1
         versionName version
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     testOptions {


### PR DESCRIPTION
- Removes `multiDexEnabled true` line in order to avoid `com.android.support:multidex:1.0.1` dependency leak

👀 @electrostat @zugaldia 