### PR TITLE
Update OkHttp version to 3.10.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
             constraintLayout : '1.0.2',
             mockito          : '2.11.0',
             testRunnerVersion: '1.0.1',
-            okhttp3          : '3.9.0',
+            okhttp3          : '3.10.0',
             gson             : '2.8.2',
             espressoVersion  : '3.0.1'
     ]

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClientSettings.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 
@@ -29,6 +30,7 @@ class TelemetryClientSettings {
   private final HttpUrl baseUrl;
   private final SSLSocketFactory sslSocketFactory;
   private final X509TrustManager x509TrustManager;
+  private final HostnameVerifier hostnameVerifier;
   private boolean debugLoggingEnabled;
 
   TelemetryClientSettings(Builder builder) {
@@ -37,6 +39,7 @@ class TelemetryClientSettings {
     this.baseUrl = builder.baseUrl;
     this.sslSocketFactory = builder.sslSocketFactory;
     this.x509TrustManager = builder.x509TrustManager;
+    this.hostnameVerifier = builder.hostnameVerifier;
     this.debugLoggingEnabled = builder.debugLoggingEnabled;
   }
 
@@ -63,6 +66,7 @@ class TelemetryClientSettings {
       .baseUrl(baseUrl)
       .sslSocketFactory(sslSocketFactory)
       .x509TrustManager(x509TrustManager)
+      .hostnameVerifier(hostnameVerifier)
       .debugLoggingEnabled(debugLoggingEnabled);
   }
 
@@ -78,6 +82,7 @@ class TelemetryClientSettings {
     HttpUrl baseUrl = null;
     SSLSocketFactory sslSocketFactory = null;
     X509TrustManager x509TrustManager = null;
+    HostnameVerifier hostnameVerifier = null;
     boolean debugLoggingEnabled = false;
 
     Builder() {
@@ -112,6 +117,11 @@ class TelemetryClientSettings {
       return this;
     }
 
+    Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+      this.hostnameVerifier = hostnameVerifier;
+      return this;
+    }
+
     Builder debugLoggingEnabled(boolean debugLoggingEnabled) {
       this.debugLoggingEnabled = debugLoggingEnabled;
       return this;
@@ -135,6 +145,7 @@ class TelemetryClientSettings {
       .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS));
     if (isSocketFactoryUnset(sslSocketFactory, x509TrustManager)) {
       builder.sslSocketFactory(sslSocketFactory, x509TrustManager);
+      builder.hostnameVerifier(hostnameVerifier);
     }
 
     return builder.build();

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
@@ -14,6 +14,9 @@ import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -172,6 +175,12 @@ class MockWebServerTest {
       .baseUrl(localUrl)
       .sslSocketFactory(sslClient.socketFactory)
       .x509TrustManager(sslClient.trustManager)
+      .hostnameVerifier(new HostnameVerifier() {
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+          return true;
+        }
+      })
       .build();
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MockWebServerTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import okhttp3.HttpUrl;
-import okhttp3.internal.tls.SslClient;
+import okhttp3.mockwebserver.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
@@ -19,7 +19,7 @@ import okhttp3.Callback;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import okhttp3.internal.tls.SslClient;
+import okhttp3.mockwebserver.internal.tls.SslClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
@@ -14,6 +14,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
@@ -183,6 +186,12 @@ public class TelemetryClientTest extends MockWebServerTest {
       .baseUrl(localUrl)
       .sslSocketFactory(sslClient.socketFactory)
       .x509TrustManager(sslClient.trustManager)
+      .hostnameVerifier(new HostnameVerifier() {
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+          return true;
+        }
+      })
       .build();
     TelemetryClient telemetryClient = new TelemetryClient("anyAccessToken", "anyUserAgent", telemetryClientSettings,
       mock(Logger.class));


### PR DESCRIPTION
- Fixes #69 
- Bumps OkHttp version to `3.10.0`
- Adds `hostnameVerifier` to `TelemetryClientSettings` builder needed to workaround stuck MockWebServer tests after bumping OkHttp version to `3.10.0`. For further details 👉 https://github.com/square/okhttp/issues/3898

cc @electrostat @zugaldia @tobrun @LukasPaczos 