### PR TITLE
Remove System.out call from MapboxTelemetry

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -316,8 +316,6 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     return new AlarmReceiver(new SchedulerCallback() {
       @Override
       public void onPeriodRaised() {
-        // TODO Remove after including UI sample app tests
-        System.out.println("MapboxTelemetry#onPeriodRaised");
         flushEnqueuedEvents();
       }
 


### PR DESCRIPTION
- Fixes #66 
- Removes `System.out` call from `MapboxTelemetry`

👀 @electrostat @zugaldia 