### PR TITLE
Fix duplicate location data issue

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -60,8 +60,7 @@ ext {
             // unit test
             junit                  : "junit:junit:${version.junit}",
             mockito                : "org.mockito:mockito-core:${version.mockito}",
-            mockitoAndroid         : "org.mockito:mockito-android:${version.mockito}",
-
+            mockitoAndroid         : "org.mockito:mockito-android:${version.mockito}"
     ]
 
     pluginDependencies = [

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/EventReceiverInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/EventReceiverInstrumentationTest.java
@@ -15,12 +15,11 @@ public class EventReceiverInstrumentationTest {
 
   @Test
   public void checksEventIntent() throws Exception {
-    EventReceiver theEventReceiver = new EventReceiver();
     Intent expectedEventIntent = new Intent("com.mapbox.event_receiver");
     expectedEventIntent.putExtra("event_received", "onEvent");
     Event mockedEvent = mock(Event.class);
 
-    Intent eventIntent = theEventReceiver.supplyIntent(mockedEvent);
+    Intent eventIntent = EventReceiver.supplyIntent(mockedEvent);
 
     assertTrue(eventIntent.filterEquals(expectedEventIntent));
     assertTrue(eventIntent.hasExtra("event_received"));

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/LocationReceiverInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/LocationReceiverInstrumentationTest.java
@@ -18,7 +18,8 @@ public class LocationReceiverInstrumentationTest {
 
   @Test
   public void checksLocationIntent() throws Exception {
-    LocationReceiver theLocationReceiver = new LocationReceiver();
+    EventCallback dummyEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(dummyEventCallback);
     Intent expectedLocationIntent = new Intent("com.mapbox.location_receiver");
     expectedLocationIntent.putExtra("location_received", "onLocation");
     Location mockedLocation = mock(Location.class);

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetryServiceTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetryServiceTest.java
@@ -30,6 +30,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksLocationReceiverIsUpWhenServiceStarted() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -43,6 +44,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksTelemetryReceiverIsUpWhenServiceStarted() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -56,6 +58,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksLocationReceiverIsDownWhenServiceStopped() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -71,6 +74,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksTelemetryReceiverIsDownWhenServiceStopped() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -86,6 +90,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksLocationReceiverIsDownWhenOnBackgroundCalled() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -100,6 +105,7 @@ public class TelemetryServiceTest {
   @Test
   public void checksTelemetryReceiverIsUpWhenOnForegroundCalled() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
@@ -115,13 +121,14 @@ public class TelemetryServiceTest {
   @Test
   public void checksOnTaskRemovedCallbackWhenOnTaskRemovedCalled() throws Exception {
     Intent serviceIntent = new Intent(InstrumentationRegistry.getTargetContext(), TelemetryService.class);
+    serviceIntent.putExtra("isLocationEnablerFromPreferences", false);
     final TelemetryService[] boundService = new TelemetryService[1];
     final CountDownLatch latchConnected = new CountDownLatch(1);
     ServiceConnection serviceConnection = setupServiceConnection(boundService, latchConnected);
     startService(serviceIntent);
     waitUntilServiceIsBound(serviceIntent, latchConnected, serviceConnection);
     ServiceTaskCallback mockedCallback = mock(ServiceTaskCallback.class);
-    boundService[0].injectServiceTask(mockedCallback);
+    boundService[0].addServiceTask(mockedCallback);
 
     boundService[0].onTaskRemoved(serviceIntent);
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventReceiver.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventReceiver.java
@@ -3,6 +3,7 @@ package com.mapbox.android.telemetry;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 
 
 class EventReceiver extends BroadcastReceiver {
@@ -12,10 +13,7 @@ class EventReceiver extends BroadcastReceiver {
   static final String EVENT_RECEIVER_INTENT = "com.mapbox.event_receiver";
   private EventCallback callback = null;
 
-  EventReceiver() {
-  }
-
-  EventReceiver(EventCallback callback) {
+  EventReceiver(@NonNull EventCallback callback) {
     this.callback = callback;
   }
 
@@ -23,14 +21,12 @@ class EventReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     String eventReceived = intent.getStringExtra(EVENT_RECEIVED_INTENT_KEY);
     if (ON_EVENT_INTENT_EXTRA.equals(eventReceived)) {
-      if (callback != null) {
-        Event event = intent.getExtras().getParcelable(EVENT_INTENT_KEY);
-        callback.onEventReceived(event);
-      }
+      Event event = intent.getExtras().getParcelable(EVENT_INTENT_KEY);
+      callback.onEventReceived(event);
     }
   }
 
-  public Intent supplyIntent(Event event) {
+  static Intent supplyIntent(Event event) {
     Intent eventIntent = new Intent(EVENT_RECEIVER_INTENT);
     eventIntent.putExtra(EVENT_RECEIVED_INTENT_KEY, ON_EVENT_INTENT_EXTRA);
     eventIntent.putExtra(EVENT_INTENT_KEY, event);

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventSender.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventSender.java
@@ -6,14 +6,12 @@ import android.support.v4.content.LocalBroadcastManager;
 
 class EventSender {
   private final Context context;
-  private final EventReceiver eventReceiver;
 
   EventSender(Context context) {
     this.context = context;
-    this.eventReceiver = new EventReceiver();
   }
 
   boolean send(Event event) {
-    return LocalBroadcastManager.getInstance(context).sendBroadcast(eventReceiver.supplyIntent(event));
+    return LocalBroadcastManager.getInstance(context).sendBroadcast(EventReceiver.supplyIntent(event));
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationReceiver.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationReceiver.java
@@ -5,20 +5,17 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
+import android.support.annotation.NonNull;
 
 class LocationReceiver extends BroadcastReceiver {
   private static final String LOCATION_RECEIVED_INTENT_KEY = "location_received";
   private static final String ON_LOCATION_INTENT_EXTRA = "onLocation";
   static final String LOCATION_RECEIVER_INTENT = "com.mapbox.location_receiver";
-  private EventSender eventSender = null;
+  private final EventCallback callback;
   private LocationMapper locationMapper = null;
 
-  LocationReceiver() {
-  }
-
-  // For testing only
-  LocationReceiver(EventSender sender) {
-    this.eventSender = sender;
+  LocationReceiver(@NonNull EventCallback callback) {
+    this.callback = callback;
   }
 
   @Override
@@ -26,7 +23,7 @@ class LocationReceiver extends BroadcastReceiver {
     String locationReceived = intent.getStringExtra(LOCATION_RECEIVED_INTENT_KEY);
     if (ON_LOCATION_INTENT_EXTRA.equals(locationReceived)) {
       Location location = (Location) intent.getExtras().get(LocationManager.KEY_LOCATION_CHANGED);
-      sendEvent(location, context);
+      sendEvent(location);
     }
   }
 
@@ -41,15 +38,14 @@ class LocationReceiver extends BroadcastReceiver {
     locationMapper.updateSessionIdentifier(sessionIdentifier);
   }
 
-  private boolean sendEvent(Location location, Context context) {
+  private boolean sendEvent(Location location) {
     if (isThereAnyNaN(location) || isThereAnyInfinite(location)) {
       return false;
     }
 
-    EventSender eventSender = obtainEventSender(context);
     LocationMapper obtainLocationEvent = obtainLocationMapper();
     LocationEvent locationEvent = obtainLocationEvent.from(location);
-    eventSender.send(locationEvent);
+    callback.onEventReceived(locationEvent);
     return true;
   }
 
@@ -61,14 +57,6 @@ class LocationReceiver extends BroadcastReceiver {
   private boolean isThereAnyInfinite(Location location) {
     return Double.isInfinite(location.getLatitude()) || Double.isInfinite(location.getLongitude())
       || Double.isInfinite(location.getAltitude()) || Float.isInfinite(location.getAccuracy());
-  }
-
-  private EventSender obtainEventSender(Context context) {
-    if (eventSender == null) {
-      eventSender = new EventSender(context);
-    }
-
-    return eventSender;
   }
 
   private LocationMapper obtainLocationMapper() {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
@@ -13,28 +13,26 @@ import static com.mapbox.android.telemetry.TelemetryUtils.obtainSharedPreference
 
 public class TelemetryEnabler {
   public enum State {
-    NOT_INITIALIZED, ENABLED, DISABLED
+    ENABLED, DISABLED
   }
 
   static final String MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE = "mapboxTelemetryState";
   static final Map<TelemetryEnabler.State, Boolean> TELEMETRY_STATES =
     new HashMap<TelemetryEnabler.State, Boolean>() {
       {
-        put(TelemetryEnabler.State.NOT_INITIALIZED, false);
         put(TelemetryEnabler.State.ENABLED, true);
         put(TelemetryEnabler.State.DISABLED, false);
       }
     };
   private static final Map<String, State> STATES = new HashMap<String, State>() {
     {
-      put(State.NOT_INITIALIZED.name(), State.NOT_INITIALIZED);
       put(State.ENABLED.name(), State.ENABLED);
       put(State.DISABLED.name(), State.DISABLED);
     }
   };
   private static final String KEY_META_DATA_ENABLED = "com.mapbox.EnableEvents";
   private boolean isFromPreferences = true;
-  private State currentTelemetryState = State.NOT_INITIALIZED;
+  private State currentTelemetryState = State.ENABLED;
 
   TelemetryEnabler(boolean isFromPreferences) {
     this.isFromPreferences = isFromPreferences;
@@ -43,9 +41,19 @@ public class TelemetryEnabler {
   public static State retrieveTelemetryStateFromPreferences() {
     SharedPreferences sharedPreferences = obtainSharedPreferences();
     String telemetryStateName = sharedPreferences.getString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE,
-      State.NOT_INITIALIZED.name());
+      State.ENABLED.name());
 
     return STATES.get(telemetryStateName);
+  }
+
+  public static State updateTelemetryState(State telemetryState) {
+    SharedPreferences sharedPreferences = obtainSharedPreferences();
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+
+    editor.putString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE, telemetryState.name());
+    editor.apply();
+
+    return telemetryState;
   }
 
   State obtainTelemetryState() {
@@ -56,17 +64,13 @@ public class TelemetryEnabler {
     return currentTelemetryState;
   }
 
-  State updateTelemetryState(State telemetryState) {
+  State updatePreferences(State telemetryState) {
     if (isFromPreferences) {
-      return updatePreferences(telemetryState);
+      return updateTelemetryState(telemetryState);
     }
 
     currentTelemetryState = telemetryState;
     return currentTelemetryState;
-  }
-
-  void injectTelemetryState(State state) {
-    currentTelemetryState = state;
   }
 
   static boolean isEventsEnabled(Context context) {
@@ -83,15 +87,5 @@ public class TelemetryEnabler {
     }
 
     return true;
-  }
-
-  private State updatePreferences(State telemetryState) {
-    SharedPreferences sharedPreferences = obtainSharedPreferences();
-    SharedPreferences.Editor editor = sharedPreferences.edit();
-
-    editor.putString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE, telemetryState.name());
-    editor.apply();
-
-    return telemetryState;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryLocationEnabler.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryLocationEnabler.java
@@ -1,0 +1,69 @@
+package com.mapbox.android.telemetry;
+
+
+import android.content.SharedPreferences;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mapbox.android.telemetry.TelemetryUtils.obtainSharedPreferences;
+
+class TelemetryLocationEnabler {
+  enum LocationState {
+    ENABLED, DISABLED
+  }
+
+  private static final String MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE = "mapboxTelemetryLocationState";
+  private static final Map<String, LocationState> LOCATION_STATES = new HashMap<String, LocationState>() {
+    {
+      put(LocationState.ENABLED.name(), LocationState.ENABLED);
+      put(LocationState.DISABLED.name(), LocationState.DISABLED);
+    }
+  };
+  private boolean isFromPreferences = true;
+  private LocationState currentTelemetryLocationState = LocationState.DISABLED;
+
+  TelemetryLocationEnabler(boolean isFromPreferences) {
+    this.isFromPreferences = isFromPreferences;
+  }
+
+  LocationState obtainTelemetryLocationState() {
+    if (isFromPreferences) {
+      return retrieveTelemetryLocationStateFromPreferences();
+    }
+
+    return currentTelemetryLocationState;
+  }
+
+  LocationState updateTelemetryLocationState(LocationState telemetryLocationState) {
+    if (isFromPreferences) {
+      return updateLocationPreferences(telemetryLocationState);
+    }
+
+    currentTelemetryLocationState = telemetryLocationState;
+    return currentTelemetryLocationState;
+  }
+
+  // For testing only
+  void injectTelemetryLocationState(LocationState locationState) {
+    currentTelemetryLocationState = locationState;
+  }
+
+  private LocationState retrieveTelemetryLocationStateFromPreferences() {
+    SharedPreferences sharedPreferences = obtainSharedPreferences();
+    String telemetryStateName = sharedPreferences.getString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE,
+      LocationState.DISABLED.name());
+
+    return LOCATION_STATES.get(telemetryStateName);
+  }
+
+  private LocationState updateLocationPreferences(LocationState telemetryLocationState) {
+    SharedPreferences sharedPreferences = obtainSharedPreferences();
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+
+    editor.putString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE, telemetryLocationState.name());
+    editor.apply();
+
+    return telemetryLocationState;
+  }
+}

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryReceiver.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryReceiver.java
@@ -3,6 +3,7 @@ package com.mapbox.android.telemetry;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 
 
 class TelemetryReceiver extends BroadcastReceiver {
@@ -13,7 +14,7 @@ class TelemetryReceiver extends BroadcastReceiver {
   static final String TELEMETRY_RECEIVER_INTENT = "com.mapbox.telemetry_receiver";
   private final TelemetryCallback callback;
 
-  TelemetryReceiver(TelemetryCallback callback) {
+  TelemetryReceiver(@NonNull TelemetryCallback callback) {
     this.callback = callback;
   }
 
@@ -21,15 +22,11 @@ class TelemetryReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     String background = intent.getStringExtra(BACKGROUND_RECEIVED_INTENT_KEY);
     if (ON_BACKGROUND_INTENT_EXTRA.equals(background)) {
-      if (callback != null) {
-        callback.onBackground();
-      }
+      callback.onBackground();
     }
     String foreground = intent.getStringExtra(FOREGROUND_RECEIVED_INTENT_KEY);
     if (ON_FOREGROUND_INTENT_EXTRA.equals(foreground)) {
-      if (callback != null) {
-        callback.onForeground();
-      }
+      callback.onForeground();
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 import okio.Buffer;
 
-class TelemetryUtils {
+public class TelemetryUtils {
   static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
   static final String MAPBOX_SHARED_PREFERENCE_KEY_VENDOR_ID = "mapboxVendorId";
   private static final String DATE_AND_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
@@ -91,7 +91,7 @@ class TelemetryUtils {
     }
   }
 
-  private static String toHumanReadableAscii(String s) {
+  public static String toHumanReadableAscii(String s) {
     for (int i = 0, length = s.length(), c; i < length; i += Character.charCount(c)) {
       c = s.codePointAt(i);
       if (c > '\u001f' && c < '\u007f') {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/AppUserTurnstileTest.java
@@ -42,7 +42,7 @@ public class AppUserTurnstileTest {
     when(mockedContext.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE))
       .thenReturn(mockedSharedPreferences);
     when(mockedSharedPreferences.getString(MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STATE,
-      TelemetryEnabler.State.NOT_INITIALIZED.name())).thenReturn(TelemetryEnabler.State.NOT_INITIALIZED.name());
+      TelemetryEnabler.State.DISABLED.name())).thenReturn(TelemetryEnabler.State.DISABLED.name());
     when(mockedSharedPreferences.getString(MAPBOX_SHARED_PREFERENCE_KEY_VENDOR_ID, "")).thenReturn("");
     SharedPreferences.Editor mockedEditor = mock(SharedPreferences.Editor.class);
     when(mockedSharedPreferences.edit()).thenReturn(mockedEditor);

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationReceiverTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationReceiverTest.java
@@ -27,12 +27,12 @@ public class LocationReceiverTest {
     when(mockedIntent.getExtras()).thenReturn(mockedBundle);
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, times(1)).send(any(LocationEvent.class));
+    verify(mockedEventCallback, times(1)).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -45,12 +45,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLatitude()).thenReturn(Double.NaN);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -63,12 +63,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLongitude()).thenReturn(Double.NaN);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -81,12 +81,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAltitude()).thenReturn(Double.NaN);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -99,12 +99,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAccuracy()).thenReturn(Float.NaN);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -117,12 +117,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLatitude()).thenReturn(Double.POSITIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -135,12 +135,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLongitude()).thenReturn(Double.POSITIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -153,12 +153,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAltitude()).thenReturn(Double.POSITIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -171,12 +171,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAccuracy()).thenReturn(Float.POSITIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -189,12 +189,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLatitude()).thenReturn(Double.NEGATIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -207,12 +207,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getLongitude()).thenReturn(Double.NEGATIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -225,12 +225,12 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAltitude()).thenReturn(Double.NEGATIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 
   @Test
@@ -243,11 +243,11 @@ public class LocationReceiverTest {
     Location mockedLocation = mock(Location.class);
     when(mockedBundle.get(eq(LocationManager.KEY_LOCATION_CHANGED))).thenReturn(mockedLocation);
     when(mockedLocation.getAccuracy()).thenReturn(Float.NEGATIVE_INFINITY);
-    EventSender mockedEventSender = mock(EventSender.class);
-    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventSender);
+    EventCallback mockedEventCallback = mock(EventCallback.class);
+    LocationReceiver theLocationReceiver = new LocationReceiver(mockedEventCallback);
 
     theLocationReceiver.onReceive(mockedContext, mockedIntent);
 
-    verify(mockedEventSender, never()).send(any(LocationEvent.class));
+    verify(mockedEventCallback, never()).onEventReceived(any(LocationEvent.class));
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapEventFactoryTest.java
@@ -7,6 +7,8 @@ import android.view.WindowManager;
 
 import org.junit.Test;
 
+import okhttp3.Callback;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -138,7 +140,17 @@ public class MapEventFactoryTest {
     MapboxTelemetry.applicationContext = mockedContext;
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";
-    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent);
+    EventsQueue mockedEventsQueue = mock(EventsQueue.class);
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    Callback mockedHttpCallback = mock(Callback.class);
+    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    Clock mockedClock = mock(Clock.class);
+    boolean indifferentServiceBound = true;
+    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
+    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
+    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent,
+      mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
+      indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
   }
 
   private MapState obtainAValidMapState() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientMapEventsTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientMapEventsTest.java
@@ -130,7 +130,17 @@ public class TelemetryClientMapEventsTest extends MockWebServerTest {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";
-    new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent);
+    EventsQueue mockedEventsQueue = mock(EventsQueue.class);
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    Callback mockedHttpCallback = mock(Callback.class);
+    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    Clock mockedClock = mock(Clock.class);
+    boolean indifferentServiceBound = true;
+    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
+    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
+    new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
+      mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
+      indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
   }
 
   private MapState obtainDefaultMapState() {


### PR DESCRIPTION
- Fixes duplicate location data issue when having multiple instances of `MapboxTelemetry`

Now `MapboxTelemetryService` (singleton by definition) is responsible for pushing the location fixes received into a single `queue` which is injected once after creating the `Service`, ensuring that only one instance of `MapboxTelemetry` receives the location events.

👀 @electrostat @zugaldia 