### PR TITLE
Bring back the Mock location engine type

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class LocationEngine {
   public enum Type {
-    GOOGLE_PLAY_SERVICES, ANDROID
+    GOOGLE_PLAY_SERVICES, ANDROID, MOCK
   }
 
   private static final int TWO_MINUTES = 1000 * 60 * 2;


### PR DESCRIPTION
- Brings back the `MOCK` `LocationEngine.Type`

Fixes #82 

cc @zugaldia @electrostat 