### PR TITLE
Set fastestInterval and smallestDisplacement in AndroidLocationEngine

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngine.java
@@ -20,8 +20,6 @@ import java.util.Map;
 class AndroidLocationEngine extends LocationEngine implements LocationListener {
 
   private static final String DEFAULT_PROVIDER = LocationManager.PASSIVE_PROVIDER;
-  private static final long DEFAULT_MIN_TIME = 0;
-  private static final float DEFAULT_MIN_DISTANCE = 0;
 
   private static AndroidLocationEngine instance;
 
@@ -106,7 +104,7 @@ class AndroidLocationEngine extends LocationEngine implements LocationListener {
   public void requestLocationUpdates() {
     if (!TextUtils.isEmpty(currentProvider)) {
       //noinspection MissingPermission
-      locationManager.requestLocationUpdates(currentProvider, DEFAULT_MIN_TIME, DEFAULT_MIN_DISTANCE, this);
+      locationManager.requestLocationUpdates(currentProvider, fastestInterval, smallestDisplacement, this);
     }
   }
 


### PR DESCRIPTION
Currently, the `AndroidLocationEngine` ignores `fastestInterval` and `smallestDisplacement` variables in favor of static constants.  This PR adds the set variables to the request when we ask the location manager for updates. 

cc @LukasPaczos @tobrun 