### PR TITLE
Fix crash when sticky service is recreated

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -46,7 +46,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
     enableTelemetryLocationState(intent);
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Nullable


### PR DESCRIPTION
- Fixes crash when `STICKY` `Service` is recreated

This is a release blocker so for now the solution taken is making the `Service` `NOT_STICKY`.
Will open a new ticket to revisit this and fix that back.

Fixes #97 

👀 @electrostat @zugaldia 