### PR TITLE
Remove unnecessary audio type setter from navigation metadata

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
@@ -209,10 +209,6 @@ public class NavigationMetadata implements Parcelable {
     return audioType;
   }
 
-  public void setAudioType(String audioType) {
-    this.audioType = audioType;
-  }
-
   Integer getStepCount() {
     return stepCount;
   }


### PR DESCRIPTION
- Removes unnecessary audio type setter from NavigationMetadata (it's not an optional field anymore)

👀 @electrostat @zugaldia 