### PR TITLE
Expose obtain universal unique identifier method publicly

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -90,6 +90,11 @@ public class TelemetryUtils {
     return s;
   }
 
+  public static String obtainUniversalUniqueIdentifier() {
+    String universalUniqueIdentifier = UUID.randomUUID().toString();
+    return universalUniqueIdentifier;
+  }
+
   static String obtainApplicationState() {
     ActivityManager activityManager = (ActivityManager) MapboxTelemetry.applicationContext
       .getSystemService(Context.ACTIVITY_SERVICE);
@@ -149,11 +154,6 @@ public class TelemetryUtils {
 
   static String generateCreateDateFormatted(Date date) {
     return dateFormat.format(date);
-  }
-
-  static String obtainUniversalUniqueIdentifier() {
-    String universalUniqueIdentifier = UUID.randomUUID().toString();
-    return universalUniqueIdentifier;
   }
 
   static String createFullUserAgent(String userAgent, Context context) {


### PR DESCRIPTION
- Exposes `TelemetryUtils#obtainUniversalUniqueIdentifier` method publicly

👀 @electrostat @zugaldia 