### PR TITLE
Add Alarm unregistering safe check

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/AlarmSchedulerFlusher.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/AlarmSchedulerFlusher.java
@@ -44,7 +44,12 @@ class AlarmSchedulerFlusher implements SchedulerFlusher {
   @Override
   public void unregister() {
     manager.cancel(pendingIntent);
-    context.unregisterReceiver(receiver);
+    try {
+      context.unregisterReceiver(receiver);
+    } catch (IllegalArgumentException exception) {
+      // No op for the cases in which the OS has unexpectedly unregistered the alarm
+      // Shouldn't happen but seen crashes in Samsung devices
+    }
   }
 
   PendingIntent obtainPendingIntent() {


### PR DESCRIPTION
- Adds `try catch` for the cases in which the OS has unexpectedly unregistered the alarm (shouldn't happen but seen crashes in Samsung devices 👉 http://crashes.to/s/f54a1694773)

👀 @electrostat @zugaldia 