### PR TITLE
Bumped libcore to 0.2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The snippet to add to your app-level `build.gradle` file to use  is the followin
 ```
 // Mapbox Core Library for Android
 
-compile 'com.mapbox.mapboxsdk:mapbox-android-core:0.1.1'
+compile 'com.mapbox.mapboxsdk:mapbox-android-core:0.2.0`
 
 ```
 


### PR DESCRIPTION
Part of the telem 3.0.0 and core 0.2.0 releases: https://github.com/mapbox/mapbox-events-android/issues/112