### PR TITLE
Add service running check

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -420,8 +420,10 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
   private void unregisterTelemetry() {
     stopAlarm();
-    unbindTelemetryService();
-    stopTelemetryService();
+    if (isMyServiceRunning(TelemetryService.class)) {
+      unbindTelemetryService();
+      stopTelemetryService();
+    }
   }
 
   private void stopAlarm() {


### PR DESCRIPTION
- Adds service running check for the cases in which the OS has unexpectedly unregistered the service (shouldn't happen but seen crashes in Samsung devices 👉 https://github.com/mapbox/mapbox-gl-native/issues/11673#issuecomment-381247571)

cc @electrostat @tobrun @zugaldia @masterjefferson