### PR TITLE
Remove unnecessary update telemetry state from enable and disable methods

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -133,7 +133,6 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
   public boolean enable() {
     if (TelemetryEnabler.isEventsEnabled(applicationContext)) {
-      telemetryEnabler.updateTelemetryState(TelemetryEnabler.State.ENABLED);
       startTelemetry();
       return true;
     }
@@ -144,7 +143,6 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   public boolean disable() {
     if (TelemetryEnabler.isEventsEnabled(applicationContext)) {
       stopTelemetry();
-      telemetryEnabler.updateTelemetryState(TelemetryEnabler.State.DISABLED);
       return true;
     }
 


### PR DESCRIPTION
- Removes unnecessary `TelemetryEnabler#updateTelemetryState` from `enable` and `disable` methods

In order to avoid problems when having multiple instances of `MapboxTelemetry` the state should be updated from one single point 👉 [`AttributionDialogManager`](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java).

cc @zugaldia @electrostat @danesfeder 