### PR TITLE
JobScheduler Context Bug

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationJobService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationJobService.java
@@ -169,6 +169,8 @@ public class LocationJobService extends JobService implements LocationListener, 
   }
 
   private LocationEvent createLocationEvent(Location location) {
+    MapboxTelemetry.applicationContext = getApplicationContext();
+
     double latitudeScaled = round(location.getLatitude());
     double longitudeScaled = round(location.getLongitude());
     double longitudeWrapped = wrapLongitude(longitudeScaled);


### PR DESCRIPTION
MapboxTelemetry.applicationContext is `null` when application containing telem sdk is force closed. 

Fixes https://github.com/mapbox/mapbox-events-android/issues/124