### PR TITLE
Bug Fix for attempting to unbind a service that is already unregistered

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -207,12 +207,12 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
       telemetryService.removeServiceTask(this);
       if (telemetryService.obtainBoundInstances() == 0
         && TelemetryLocationEnabler.LocationState.ENABLED.equals(telemetryLocationState)) {
-        applicationContext.unbindService(serviceConnection);
+        unbindServiceConnection();
         isServiceBound = false;
         stopLocation();
         isLocationOpted = false;
       } else {
-        applicationContext.unbindService(serviceConnection);
+        unbindServiceConnection();
         isServiceBound = false;
       }
     }
@@ -431,7 +431,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   private void unbindTelemetryService() {
     if (isServiceBound) {
       telemetryService.unbindInstance();
-      applicationContext.unbindService(serviceConnection);
+      unbindServiceConnection();
     }
   }
 
@@ -517,5 +517,14 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
   private void stopLocation() {
     applicationContext.stopService(obtainLocationServiceIntent());
+  }
+
+  private boolean unbindServiceConnection() {
+    if (TelemetryUtils.isServiceRunning(TelemetryService.class)) {
+      applicationContext.unbindService(serviceConnection);
+      return true;
+    }
+
+    return false;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -216,4 +216,15 @@ public class TelemetryUtils {
     IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     return context.registerReceiver(null, filter);
   }
+
+  static boolean isServiceRunning(Class<?> serviceClass) {
+    ActivityManager manager = (ActivityManager) MapboxTelemetry.applicationContext
+      .getSystemService(Context.ACTIVITY_SERVICE);
+    for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+      if (serviceClass.getName().equals(service.service.getClassName())) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.app.ActivityManager;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -212,6 +213,9 @@ public class MapboxTelemetryTest {
     TelemetryService mockedTelemetryService = mock(TelemetryService.class);
     MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, serviceBound, mockedTelemetryService,
       TelemetryLocationEnabler.LocationState.ENABLED);
+    ActivityManager mockedActivityManager = mock(ActivityManager.class);
+    when(mockedContext.getSystemService(Context.ACTIVITY_SERVICE))
+      .thenReturn(mockedActivityManager);
 
     theMapboxTelemetry.disable();
 


### PR DESCRIPTION
Check if service is running and if it is, then unbind and continue on process. Prevents crash and keeps system working.