### PR TITLE
Oreo Background Service Fix

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,8 +2,8 @@ ext {
 
     androidVersions = [
             minSdkVersion    : 14,
-            targetSdkVersion : 25,
-            compileSdkVersion: 25,
+            targetSdkVersion : 26,
+            compileSdkVersion: 26,
             buildToolsVersion: '27.0.2'
     ]
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -8,7 +8,9 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.os.IBinder;
+import android.support.v4.content.ContextCompat;
 
 import com.mapbox.android.core.location.LocationEnginePriority;
 import com.mapbox.android.core.permissions.PermissionsManager;
@@ -487,7 +489,11 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private void startLocation() {
-    applicationContext.startService(obtainLocationServiceIntent());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      applicationContext.startForegroundService(obtainLocationServiceIntent());
+    } else {
+      applicationContext.startService(obtainLocationServiceIntent());
+    }
   }
 
   private void startAlarm() {


### PR DESCRIPTION
Running into background service crash associated with Oreo. This PR is to fix and prevent, before full Oreo update is finished.