### PR TITLE
GoogleLocationEngine lack of priority crash

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngine.java
@@ -22,6 +22,8 @@ import java.util.Map;
 class GoogleLocationEngine extends LocationEngine implements
   GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener, LocationListener {
 
+  private static final LocationEnginePriority DEFAULT_PRIORITY = LocationEnginePriority.NO_POWER;
+
   private WeakReference<Context> context;
   private GoogleApiClient googleApiClient;
   private final Map<LocationEnginePriority, UpdateGoogleRequestPriority> REQUEST_PRIORITY = new
@@ -62,6 +64,7 @@ class GoogleLocationEngine extends LocationEngine implements
       .addOnConnectionFailedListener(this)
       .addApi(LocationServices.API)
       .build();
+    this.priority = DEFAULT_PRIORITY;
   }
 
   static synchronized LocationEngine getLocationEngine(Context context) {


### PR DESCRIPTION
GoogleLocationEngine will crash when requestingLocation due to a lack of priority, unless it is manually set by the dev. Set and create a default priority level of `NO_POWER` to fix this issue.

Fixes https://github.com/mapbox/mapbox-events-android/issues/169
Fixes https://github.com/mapbox/mapbox-events-android/issues/132