### PR TITLE
Reduce API level for Current State check to Lollipop

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -494,7 +494,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private void startLocation() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       if (ProcessLifecycleOwner.get().getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
         applicationContext.startService(obtainLocationServiceIntent());
       } else {


### PR DESCRIPTION
Reduce API level of current state check for `startService`. Was able to test solution on devices running Lollipop and above.

Fixes https://github.com/mapbox/mapbox-events-android/issues/174 for devices running Lollipop+, need to obtain test devices for lower API levels.