### PR TITLE
Update Proguard Rules for GMS

### DIFF
--- a/libcore/proguard-consumer.pro
+++ b/libcore/proguard-consumer.pro
@@ -1,5 +1,5 @@
 # Consumer proguard rules for libcore
 
 # --- GMS ---
--keep public class com.google.android.gms.* { public *; }
+-keep class com.google.android.gms.** { *; }
 -dontwarn com.google.android.gms.**


### PR DESCRIPTION
Change proguard rules for GMS to prevent a non-functioning GoogleLocationEngine

Fixes https://github.com/mapbox/mapbox-events-android/issues/185