### PR TITLE
checkApplicationContext when stopping service

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -66,6 +66,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
 
   @Override
   public void onDestroy() {
+    checkApplicationContext();
     unregisterLocationReceiver();
     unregisterTelemetryReceiver();
     disableTelemetryLocationState();


### PR DESCRIPTION
Add `checkApplicationContext()` to workflow of stopping `TelemetryService`. This will prevent a NPE when attempting to run processes on service shutdown under certain circumstances.

Fixes https://github.com/mapbox/mapbox-events-android/issues/181