### PR TITLE
Create General VisionEvent

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/Event.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/Event.java
@@ -9,12 +9,13 @@ public abstract class Event implements Parcelable {
 
   public enum Type {
     TURNSTILE, MAP_LOAD, MAP_CLICK, MAP_DRAGEND, LOCATION, NAV_DEPART, NAV_ARRIVE, NAV_CANCEL, NAV_REROUTE,
-    NAV_FEEDBACK, NAV_FASTER_ROUTE
+    NAV_FEEDBACK, NAV_FASTER_ROUTE, VIS_GENERAL
   }
 
   static EnumSet<Type> mapGestureEventTypes = EnumSet.of(Type.MAP_CLICK, Type.MAP_DRAGEND);
   static EnumSet<Type> navigationEventTypes = EnumSet.of(Type.NAV_DEPART, Type.NAV_ARRIVE, Type.NAV_CANCEL,
     Type.NAV_REROUTE, Type.NAV_FEEDBACK, Type.NAV_FASTER_ROUTE);
+  static EnumSet<Type> visionEventTypes = EnumSet.of(Type.VIS_GENERAL);
 
   abstract Type obtainType();
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionBuildEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionBuildEvent.java
@@ -1,0 +1,7 @@
+package com.mapbox.android.telemetry;
+
+import java.util.HashMap;
+
+public interface VisionBuildEvent {
+  Event build(String name, HashMap<String, Object> contents);
+}

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionBuildEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionBuildEvent.java
@@ -1,7 +1,5 @@
 package com.mapbox.android.telemetry;
 
-import java.util.HashMap;
-
 public interface VisionBuildEvent {
-  Event build(String name, HashMap<String, Object> contents);
+  Event build();
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEvent.java
@@ -13,19 +13,29 @@ public class VisionEvent  extends Event implements Parcelable {
   @SerializedName("event")
   private final String event;
   @SerializedName("name")
-  private String name;
+  private String name = "";
   @SerializedName("contents")
-  private HashMap<String, Object> contents;
+  private HashMap<String, Object> contents = new HashMap<>();
 
-  VisionEvent(String name, HashMap<String, Object> contents) {
+  VisionEvent() {
     this.event = VIS_GENERAL;
-    this.name = name;
-    this.contents = contents;
   }
 
   @Override
   Type obtainType() {
     return Type.VIS_GENERAL;
+  }
+
+  public void setContents(HashMap<String, Object> contents) {
+    this.contents = contents;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public HashMap<String, Object> getContents() {
+    return contents;
   }
 
   private VisionEvent(Parcel in) {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEvent.java
@@ -1,0 +1,60 @@
+package com.mapbox.android.telemetry;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+
+public class VisionEvent  extends Event implements Parcelable {
+  private static final String VIS_GENERAL = "vision.general";
+
+  @SerializedName("event")
+  private final String event;
+  @SerializedName("name")
+  private String name;
+  @SerializedName("contents")
+  private HashMap<String, Object> contents;
+
+  VisionEvent(String name, HashMap<String, Object> contents) {
+    this.event = VIS_GENERAL;
+    this.name = name;
+    this.contents = contents;
+  }
+
+  @Override
+  Type obtainType() {
+    return Type.VIS_GENERAL;
+  }
+
+  private VisionEvent(Parcel in) {
+    event = in.readString();
+    name = in.readString();
+    contents = (HashMap<String, Object>) in.readSerializable();
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeString(event);
+    dest.writeString(name);
+    dest.writeSerializable(this.contents);
+  }
+
+  public static final Creator<VisionEvent> CREATOR = new Creator<VisionEvent>() {
+    @Override
+    public VisionEvent createFromParcel(Parcel in) {
+      return new VisionEvent(in);
+    }
+
+    @Override
+    public VisionEvent[] newArray(int size) {
+      return new VisionEvent[size];
+    }
+  };
+}

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEventFactory.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEventFactory.java
@@ -7,15 +7,13 @@ public class VisionEventFactory {
   private static final String APPLICATION_CONTEXT_CANT_BE_NULL = "Create a MapboxTelemetry instance before calling "
     + "this method.";
   private static final String NOT_A_VISION_EVENT_TYPE = "Type must be a vision event.";
-  private static final String NAME_ILLEGAL_NULL = "Name cannot be null.";
-  private static final String CONTENTS_ILLEGAL_NULL = "Contents cannot be null.";
 
   private final Map<Event.Type, VisionBuildEvent> BUILD_EVENT_VISION = new HashMap<Event.Type, VisionBuildEvent>() {
     {
       put(Event.Type.VIS_GENERAL, new VisionBuildEvent() {
         @Override
-        public Event build(String name, HashMap<String, Object> contents) {
-          return buildVisionEvent(name, contents);
+        public Event build() {
+          return buildVisionEvent();
         }
       });
     }
@@ -27,37 +25,23 @@ public class VisionEventFactory {
     }
   }
 
-  public Event createVisionEvent(Event.Type type, String name,  HashMap<String, Object> contents) {
-    checkVisionEvent(type, name, contents);
-    return BUILD_EVENT_VISION.get(type).build(name, contents);
+  public Event createVisionEvent(Event.Type type) {
+    checkVisionEvent(type);
+    return BUILD_EVENT_VISION.get(type).build();
   }
 
-  private VisionEvent buildVisionEvent(String name, HashMap<String, Object> contents) {
-    VisionEvent visionEvent = new VisionEvent(name, contents);
+  private VisionEvent buildVisionEvent() {
+    VisionEvent visionEvent = new VisionEvent();
     return visionEvent;
   }
 
-  private void checkVisionEvent(Event.Type type, String name, HashMap<String, Object> contents) {
+  private void checkVisionEvent(Event.Type type) {
     checkEventType(type);
-    nameIsNotNull(name);
-    contentsAreNotNull(contents);
   }
 
   private void checkEventType(Event.Type type) {
     if (!Event.visionEventTypes.contains(type)) {
       throw new IllegalArgumentException(NOT_A_VISION_EVENT_TYPE);
-    }
-  }
-
-  private void nameIsNotNull(String name) {
-    if (name == null) {
-      throw new IllegalArgumentException(NAME_ILLEGAL_NULL);
-    }
-  }
-
-  private void contentsAreNotNull(HashMap<String, Object> contents) {
-    if (contents == null) {
-      throw new IllegalArgumentException(CONTENTS_ILLEGAL_NULL);
     }
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEventFactory.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/VisionEventFactory.java
@@ -1,0 +1,63 @@
+package com.mapbox.android.telemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class VisionEventFactory {
+  private static final String APPLICATION_CONTEXT_CANT_BE_NULL = "Create a MapboxTelemetry instance before calling "
+    + "this method.";
+  private static final String NOT_A_VISION_EVENT_TYPE = "Type must be a vision event.";
+  private static final String NAME_ILLEGAL_NULL = "Name cannot be null.";
+  private static final String CONTENTS_ILLEGAL_NULL = "Contents cannot be null.";
+
+  private final Map<Event.Type, VisionBuildEvent> BUILD_EVENT_VISION = new HashMap<Event.Type, VisionBuildEvent>() {
+    {
+      put(Event.Type.VIS_GENERAL, new VisionBuildEvent() {
+        @Override
+        public Event build(String name, HashMap<String, Object> contents) {
+          return buildVisionEvent(name, contents);
+        }
+      });
+    }
+  };
+
+  public VisionEventFactory() {
+    if (MapboxTelemetry.applicationContext == null) {
+      throw new IllegalStateException(APPLICATION_CONTEXT_CANT_BE_NULL);
+    }
+  }
+
+  public Event createVisionEvent(Event.Type type, String name,  HashMap<String, Object> contents) {
+    checkVisionEvent(type, name, contents);
+    return BUILD_EVENT_VISION.get(type).build(name, contents);
+  }
+
+  private VisionEvent buildVisionEvent(String name, HashMap<String, Object> contents) {
+    VisionEvent visionEvent = new VisionEvent(name, contents);
+    return visionEvent;
+  }
+
+  private void checkVisionEvent(Event.Type type, String name, HashMap<String, Object> contents) {
+    checkEventType(type);
+    nameIsNotNull(name);
+    contentsAreNotNull(contents);
+  }
+
+  private void checkEventType(Event.Type type) {
+    if (!Event.visionEventTypes.contains(type)) {
+      throw new IllegalArgumentException(NOT_A_VISION_EVENT_TYPE);
+    }
+  }
+
+  private void nameIsNotNull(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException(NAME_ILLEGAL_NULL);
+    }
+  }
+
+  private void contentsAreNotNull(HashMap<String, Object> contents) {
+    if (contents == null) {
+      throw new IllegalArgumentException(CONTENTS_ILLEGAL_NULL);
+    }
+  }
+}

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 public class VisionEventFactoryTest {
 
   @Test(expected = IllegalStateException.class)
-  public void checksMapboxTelemetryNotInitialized() throws Exception {
+  public void checksMapboxTelemetryNotInitialized() {
     MapboxTelemetry.applicationContext = null;
 
     new VisionEventFactory();

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
@@ -7,8 +7,6 @@ import android.view.WindowManager;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-
 import okhttp3.Callback;
 
 import static org.junit.Assert.assertEquals;
@@ -30,10 +28,8 @@ public class VisionEventFactoryTest {
   public void checksVisionEvent() {
     initializeMapboxTelemetry();
     VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String anyName = "anyName";
-    HashMap mockedContents = mock(HashMap.class);
 
-    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, mockedContents);
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL);
 
     assertTrue(visonEvent instanceof VisionEvent);
   }
@@ -42,10 +38,8 @@ public class VisionEventFactoryTest {
   public void checksVisionType() {
     initializeMapboxTelemetry();
     VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String anyName = "anyName";
-    HashMap mockedContents = mock(HashMap.class);
 
-    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, mockedContents);
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL);
 
     assertEquals(Event.Type.VIS_GENERAL, visonEvent.obtainType());
   }
@@ -54,55 +48,9 @@ public class VisionEventFactoryTest {
   public void checksVisionInvalidType() {
     initializeMapboxTelemetry();
     VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String anyName = "anyName";
-    HashMap mockedContents = mock(HashMap.class);
     Event.Type notAVisionType = Event.Type.MAP_CLICK;
 
-    aVisionEventFactory.createVisionEvent(notAVisionType, anyName, mockedContents);
-  }
-
-  @Test
-  public void checksValidName() {
-    initializeMapboxTelemetry();
-    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String validName = "validName";
-    HashMap mockedContents = mock(HashMap.class);
-
-    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, validName, mockedContents);
-
-    assertTrue(visonEvent instanceof VisionEvent);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checksInvalidName() {
-    initializeMapboxTelemetry();
-    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String nullName = null;
-    HashMap mockedContents = mock(HashMap.class);
-
-    aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, nullName, mockedContents);
-  }
-
-  @Test
-  public void checksValidContents() {
-    initializeMapboxTelemetry();
-    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String anyName = "anyName";
-    HashMap validContents = mock(HashMap.class);
-
-    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, validContents);
-
-    assertTrue(visonEvent instanceof VisionEvent);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checksInvalidContents() {
-    initializeMapboxTelemetry();
-    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
-    String anyName = "anyName";
-    HashMap nullContents = null;
-
-    aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, nullContents);
+    aVisionEventFactory.createVisionEvent(notAVisionType);
   }
 
   private void initializeMapboxTelemetry() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
@@ -1,0 +1,131 @@
+package com.mapbox.android.telemetry;
+
+import android.app.AlarmManager;
+import android.content.Context;
+import android.telephony.TelephonyManager;
+import android.view.WindowManager;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import okhttp3.Callback;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VisionEventFactoryTest {
+
+  @Test(expected = IllegalStateException.class)
+  public void checksMapboxTelemetryNotInitialized() throws Exception {
+    MapboxTelemetry.applicationContext = null;
+
+    new VisionEventFactory();
+  }
+
+  @Test
+  public void checksVisionEvent() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String anyName = "anyName";
+    HashMap mockedContents = mock(HashMap.class);
+
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, mockedContents);
+
+    assertTrue(visonEvent instanceof VisionEvent);
+  }
+
+  @Test
+  public void checksVisionType() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String anyName = "anyName";
+    HashMap mockedContents = mock(HashMap.class);
+
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, mockedContents);
+
+    assertEquals(Event.Type.VIS_GENERAL, visonEvent.obtainType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checksVisionInvalidType() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String anyName = "anyName";
+    HashMap mockedContents = mock(HashMap.class);
+    Event.Type notAVisionType = Event.Type.MAP_CLICK;
+
+    aVisionEventFactory.createVisionEvent(notAVisionType, anyName, mockedContents);
+  }
+
+  @Test
+  public void checksValidName() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String validName = "validName";
+    HashMap mockedContents = mock(HashMap.class);
+
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, validName, mockedContents);
+
+    assertTrue(visonEvent instanceof VisionEvent);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checksInvalidName() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String nullName = null;
+    HashMap mockedContents = mock(HashMap.class);
+
+    aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, nullName, mockedContents);
+  }
+
+  @Test
+  public void checksValidContents() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String anyName = "anyName";
+    HashMap validContents = mock(HashMap.class);
+
+    Event visonEvent = aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, validContents);
+
+    assertTrue(visonEvent instanceof VisionEvent);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checksInvalidContents() {
+    initializeMapboxTelemetry();
+    VisionEventFactory aVisionEventFactory = new VisionEventFactory();
+    String anyName = "anyName";
+    HashMap nullContents = null;
+
+    aVisionEventFactory.createVisionEvent(Event.Type.VIS_GENERAL, anyName, nullContents);
+  }
+
+  private void initializeMapboxTelemetry() {
+    Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
+    TelephonyManager mockedTelephonyManager = mock(TelephonyManager.class, RETURNS_DEEP_STUBS);
+    when(mockedContext.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(mockedTelephonyManager);
+    WindowManager mockedWindowManager = mock(WindowManager.class, RETURNS_DEEP_STUBS);
+    when(mockedContext.getSystemService(Context.WINDOW_SERVICE)).thenReturn(mockedWindowManager);
+    AlarmManager mockedAlarmManager = mock(AlarmManager.class, RETURNS_DEEP_STUBS);
+    when(mockedContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mockedAlarmManager);
+    MapboxTelemetry.applicationContext = mockedContext;
+    String aValidAccessToken = "validAccessToken";
+    String aValidUserAgent = "MapboxTelemetryAndroid/";
+    EventsQueue mockedEventsQueue = mock(EventsQueue.class);
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    Callback mockedHttpCallback = mock(Callback.class);
+    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    Clock mockedClock = mock(Clock.class);
+    boolean indifferentServiceBound = true;
+    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
+    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
+    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent,
+      mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
+      indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
+  }
+}


### PR DESCRIPTION
Create a general vision event for the initial integration of the telemetry sdk into the Vision sdk. Will allow VisionSDK to send back custom telemetry data and iterate during testing.