### PR TITLE
Update MOCK LocationEngine Type to REPLAY

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class LocationEngine {
   public enum Type {
-    GOOGLE_PLAY_SERVICES, ANDROID, MOCK
+    GOOGLE_PLAY_SERVICES, ANDROID, REPLAY
   }
 
   private static final int TWO_MINUTES = 1000 * 60 * 2;


### PR DESCRIPTION
With https://github.com/mapbox/mapbox-navigation-android/pull/1039, the navigation repository is removing the `MockLocationEngine` in favor of a `ReplayRouteLocationEngine`.  

This PR is just updating the `Type` `enum` to better reflect the new naming on our side.  If this doesn't make sense or there is a better way to address this, I'm happy to update this PR or close.  

cc @andrlee 