### PR TITLE
Re-add MOCK LocationEngine Type

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngine.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class LocationEngine {
   public enum Type {
-    GOOGLE_PLAY_SERVICES, ANDROID, REPLAY
+    GOOGLE_PLAY_SERVICES, ANDROID, MOCK
   }
 
   private static final int TWO_MINUTES = 1000 * 60 * 2;


### PR DESCRIPTION
Per @Guardiola31337's comment > https://github.com/mapbox/mapbox-events-android/pull/215#issuecomment-420947181 it might make sense to re-add the `MOCK` type to avoid a SEMVER major breakage.  

Ultimately up to ya'll @electrostat @andrlee, thanks for the 👀  