### PR TITLE
More specific Proguard rules

### DIFF
--- a/libcore/proguard-consumer.pro
+++ b/libcore/proguard-consumer.pro
@@ -1,6 +1,4 @@
 # Consumer proguard rules for libcore
 
 # --- GMS ---
--keep class com.google.android.gms.location.** { *; }
--keep class com.google.android.gms.common.** { *; }
 -dontwarn com.google.android.gms.**

--- a/libcore/proguard-consumer.pro
+++ b/libcore/proguard-consumer.pro
@@ -1,5 +1,6 @@
 # Consumer proguard rules for libcore
 
 # --- GMS ---
--keep class com.google.android.gms.** { *; }
+-keep class com.google.android.gms.location.** { *; }
+-keep class com.google.android.gms.common.** { *; }
 -dontwarn com.google.android.gms.**


### PR DESCRIPTION
Update proguard rules to be more specific and lower method counts. We utilize `common` and `location` within the `Core` library and will keep only those.

fixes https://github.com/mapbox/mapbox-events-android/issues/199