### PR TITLE
Telemetry proguard configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            minifyEnabled false
+        }
         release {
             minifyEnabled true
         }

--- a/libtelemetry/proguard-consumer.pro
+++ b/libtelemetry/proguard-consumer.pro
@@ -1,7 +1,15 @@
 # Consumer proguard rules for libtelemetry
 
-# --- OkHttp ---
--dontwarn okhttp3.**
--dontwarn okio.**
-# A resource is loaded with a relative path so the package of this class must be preserved.
+# OkHttp configuration from https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+-dontwarn javax.annotation.**
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+-dontnote okhttp3.internal.platform.**
+
+# Gson
+-dontnote sun.misc.Unsafe
+
+# don't note duplciate class definitions, https://issuetracker.google.com/issues/37070898
+-dontnote android.net.http.**
+-dontnote org.apache.http.**


### PR DESCRIPTION
Revisiting the proguard configuration [downstream](https://github.com/mapbox/mapbox-gl-native/pull/12929) showed that many warnings and notes were coming from the telemetry library. This PR revisits the telemetry proguard configuration by:
 - relying on the [default](https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro) okhttp configuration.
 - `dontnote sun.misc.Unsafe`, which is safe to don't note when using gson.
 - don't note `duplicate class definitions` see  https://issuetracker.google.com/issues/37070898 for context.