### PR TITLE
StopTelemetryService obtainBoundInstances bug fix

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -466,13 +466,15 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private void stopTelemetryService() {
+    if (telemetryService != null) {
+      return;
+    }
+
     TelemetryLocationEnabler.LocationState telemetryLocationState = telemetryLocationEnabler
       .obtainTelemetryLocationState();
-    if (telemetryService != null) {
-      if (telemetryService.obtainBoundInstances() == 0
-        && TelemetryLocationEnabler.LocationState.ENABLED.equals(telemetryLocationState)) {
-        stopLocation();
-      }
+    if (telemetryService.obtainBoundInstances() == 0
+      && TelemetryLocationEnabler.LocationState.ENABLED.equals(telemetryLocationState)) {
+      stopLocation();
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -468,9 +468,11 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   private void stopTelemetryService() {
     TelemetryLocationEnabler.LocationState telemetryLocationState = telemetryLocationEnabler
       .obtainTelemetryLocationState();
-    if (telemetryService.obtainBoundInstances() == 0
-      && TelemetryLocationEnabler.LocationState.ENABLED.equals(telemetryLocationState)) {
-      stopLocation();
+    if (telemetryService != null) {
+      if (telemetryService.obtainBoundInstances() == 0
+        && TelemetryLocationEnabler.LocationState.ENABLED.equals(telemetryLocationState)) {
+        stopLocation();
+      }
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -164,7 +164,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   public boolean updateSessionIdRotationInterval(SessionInterval interval) {
-    if (isServiceBound) {
+    if (isServiceBound && telemetryService != null) {
       int hour = interval.obtainInterval();
       SessionIdentifier sessionIdentifier = new SessionIdentifier(hour);
       telemetryService.updateSessionIdentifier(sessionIdentifier);
@@ -186,7 +186,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   public void updateLocationPriority(LocationEnginePriority locationPriority) {
-    if (isServiceBound) {
+    if (isServiceBound && telemetryService != null) {
       telemetryService.updateLocationPriority(locationPriority);
     }
   }
@@ -224,7 +224,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   boolean optLocationOut() {
     TelemetryLocationEnabler.LocationState telemetryLocationState = telemetryLocationEnabler
       .obtainTelemetryLocationState();
-    if (isServiceBound) {
+    if (isServiceBound && telemetryService != null) {
       telemetryService.unbindInstance();
       telemetryService.removeServiceTask(this);
       if (telemetryService.obtainBoundInstances() == 0
@@ -459,14 +459,14 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private void unbindTelemetryService() {
-    if (isServiceBound) {
+    if (isServiceBound && telemetryService != null) {
       telemetryService.unbindInstance();
       unbindServiceConnection();
     }
   }
 
   private void stopTelemetryService() {
-    if (telemetryService != null) {
+    if (telemetryService == null) {
       return;
     }
 


### PR DESCRIPTION
Under certain circumstances, `telemetryService` is null and causes a crash when calling `obtainBoundInstances()` within `stopTelemetryService`. Add in check to prevent crash.

Fixes https://github.com/mapbox/mapbox-events-android/issues/188