### PR TITLE
Fix FileAttachment Queue Bug

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -241,6 +241,10 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     return isLocationOpted;
   }
 
+  EventsQueue getQueue() {
+    return queue;
+  }
+
   private void startTelemetryService() {
     TelemetryLocationEnabler.LocationState telemetryLocationState = telemetryLocationEnabler
       .obtainTelemetryLocationState();

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -241,8 +241,8 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     return isLocationOpted;
   }
 
-  EventsQueue getQueue() {
-    return queue;
+  Boolean isQueueEmpty() {
+    return queue.queue.size() == 0;
   }
 
   private void startTelemetryService() {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -241,7 +241,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     return isLocationOpted;
   }
 
-  Boolean isQueueEmpty() {
+  boolean isQueueEmpty() {
     return queue.queue.size() == 0;
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -488,6 +488,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
     if (Event.Type.VIS_ATTACHMENT.equals((event.obtainType()))) {
       sendAttachment(event);
+      return true;
     }
 
     return false;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -588,8 +588,8 @@ public class MapboxTelemetryTest {
     return mapboxTelemetry;
   }
 
-  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, EventsQueue eventsQueue, TelemetryEnabler.State
-    state) {
+  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, EventsQueue eventsQueue,
+                                                    TelemetryEnabler.State state) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -495,6 +495,24 @@ public class MapboxTelemetryTest {
     assertTrue(theMapboxTelemetry.isQueueEmpty());
   }
 
+  private MapboxTelemetry obtainMapboxTelemetry() {
+    MapboxTelemetry.applicationContext = obtainNetworkConnectedMockedContext();
+    String aValidAccessToken = "validAccessToken";
+    String aValidUserAgent = "MapboxTelemetryAndroid/";
+    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
+    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    TelemetryClient telemetryClient = mock(TelemetryClient.class);
+    Callback httpCallback = mock(Callback.class);
+    Clock mockedClock = mock(Clock.class);
+    boolean indifferentServiceBound = true;
+    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
+    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
+    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(MapboxTelemetry.applicationContext,
+      aValidAccessToken, aValidUserAgent, eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher,
+      mockedClock, indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
+    return mapboxTelemetry;
+  }
+
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
@@ -567,24 +585,6 @@ public class MapboxTelemetryTest {
     MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
       mockedEventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
       indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
-    return mapboxTelemetry;
-  }
-
-  private MapboxTelemetry obtainMapboxTelemetry() {
-    MapboxTelemetry.applicationContext = obtainNetworkConnectedMockedContext();
-    String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
-    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
-    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
-    TelemetryClient telemetryClient = mock(TelemetryClient.class);
-    Callback httpCallback = mock(Callback.class);
-    Clock mockedClock = mock(Clock.class);
-    boolean indifferentServiceBound = true;
-    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
-    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(MapboxTelemetry.applicationContext,
-      aValidAccessToken, aValidUserAgent, eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher,
-      mockedClock, indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
     return mapboxTelemetry;
   }
 

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -475,34 +475,24 @@ public class MapboxTelemetryTest {
 
   @Test
   public void checksAppUserTurnstileNotQueued() throws Exception {
-    Context mockedContext = obtainNetworkConnectedMockedContext();
-    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
-    Callback mockedHttpCallback = mock(Callback.class);
-    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, mockedTelemetryClient,
-      mockedHttpCallback, eventsQueue);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetry();
 
     Event whitelistedEvent = new AppUserTurnstile("anySdkIdentifier", "anySdkVersion", false);
     theMapboxTelemetry.enable();
     theMapboxTelemetry.push(whitelistedEvent);
 
-    assertEquals(0, theMapboxTelemetry.getQueue().queue.size());
+    assertTrue(theMapboxTelemetry.isQueueEmpty());
   }
 
   @Test
   public void checksAttachmentEventNotQueued() throws Exception {
-    Context mockedContext = obtainNetworkConnectedMockedContext();
-    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
-    Callback mockedHttpCallback = mock(Callback.class);
-    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, mockedTelemetryClient,
-      mockedHttpCallback, eventsQueue);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetry();
 
     Event whitelistedEvent = new Attachment();
     theMapboxTelemetry.enable();
     theMapboxTelemetry.push(whitelistedEvent);
 
-    assertEquals(0, theMapboxTelemetry.getQueue().queue.size());
+    assertTrue(theMapboxTelemetry.isQueueEmpty());
   }
 
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context) {
@@ -580,19 +570,21 @@ public class MapboxTelemetryTest {
     return mapboxTelemetry;
   }
 
-  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, TelemetryClient telemetryClient,
-                                                    Callback httpCallback, EventsQueue eventsQueue) {
-    MapboxTelemetry.applicationContext = context;
+  private MapboxTelemetry obtainMapboxTelemetry() {
+    MapboxTelemetry.applicationContext = obtainNetworkConnectedMockedContext();
     String aValidAccessToken = "validAccessToken";
     String aValidUserAgent = "MapboxTelemetryAndroid/";
+    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    TelemetryClient telemetryClient = mock(TelemetryClient.class);
+    Callback httpCallback = mock(Callback.class);
     Clock mockedClock = mock(Clock.class);
     boolean indifferentServiceBound = true;
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
     TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
-    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
-      eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
-      indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
+    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(MapboxTelemetry.applicationContext,
+      aValidAccessToken, aValidUserAgent, eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher,
+      mockedClock, indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
     return mapboxTelemetry;
   }
 

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -473,6 +473,38 @@ public class MapboxTelemetryTest {
     assertFalse(notUpdatedSessionInterval);
   }
 
+  @Test
+  public void checksAppUserTurnstileNotQueued() throws Exception {
+    Context mockedContext = obtainNetworkConnectedMockedContext();
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    Callback mockedHttpCallback = mock(Callback.class);
+    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, mockedTelemetryClient,
+      mockedHttpCallback, eventsQueue);
+
+    Event whitelistedEvent = new AppUserTurnstile("anySdkIdentifier", "anySdkVersion", false);
+    theMapboxTelemetry.enable();
+    theMapboxTelemetry.push(whitelistedEvent);
+
+    assertEquals(0, theMapboxTelemetry.getQueue().queue.size());
+  }
+
+  @Test
+  public void checksAttachmentEventNotQueued() throws Exception {
+    Context mockedContext = obtainNetworkConnectedMockedContext();
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    Callback mockedHttpCallback = mock(Callback.class);
+    EventsQueue eventsQueue = new EventsQueue(mock(FlushQueueCallback.class));
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, mockedTelemetryClient,
+      mockedHttpCallback, eventsQueue);
+
+    Event whitelistedEvent = new Attachment();
+    theMapboxTelemetry.enable();
+    theMapboxTelemetry.push(whitelistedEvent);
+
+    assertEquals(0, theMapboxTelemetry.getQueue().queue.size());
+  }
+
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
@@ -544,6 +576,22 @@ public class MapboxTelemetryTest {
     TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
     MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
       mockedEventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
+      indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
+    return mapboxTelemetry;
+  }
+
+  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, TelemetryClient telemetryClient,
+                                                    Callback httpCallback, EventsQueue eventsQueue) {
+    MapboxTelemetry.applicationContext = context;
+    String aValidAccessToken = "validAccessToken";
+    String aValidUserAgent = "MapboxTelemetryAndroid/";
+    SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
+    Clock mockedClock = mock(Clock.class);
+    boolean indifferentServiceBound = true;
+    TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
+    TelemetryLocationEnabler telemetryLocationEnabler = new TelemetryLocationEnabler(false);
+    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
+      eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
       indifferentServiceBound, telemetryEnabler, telemetryLocationEnabler);
     return mapboxTelemetry;
   }


### PR DESCRIPTION
Prevent `FileAttachment` event from being added to queue, in addition to sending it up through attachment logic.

Add in unit test to confirm that `whitelisted` events are not added to queue.\

Fixes https://github.com/mapbox/mapbox-events-android/issues/225