### PR TITLE
ACCESS_FINE_LOCATION permission exception

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -39,7 +39,6 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   private LocationEnginePriority locationPriority = LocationEnginePriority.NO_POWER;
   private CopyOnWriteArraySet<ServiceTaskCallback> serviceTaskCallbacks = null;
   private TelemetryLocationEnabler telemetryLocationEnabler;
-  private Logger logger;
   // For testing only:
   private boolean isLocationEnablerFromPreferences = true;
   private boolean isLocationReceiverRegistered = false;
@@ -48,7 +47,6 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
   @Override
   public void onCreate() {
     super.onCreate();
-    this.logger = new Logger();
     createLocationReceiver();
     createTelemetryReceiver();
     createServiceTaskCallbacks();
@@ -292,20 +290,26 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
       int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
         Manifest.permission.ACCESS_FINE_LOCATION);
 
-      checkFinePermission(finePermission);
+      if (checkFinePermission(finePermission)) {
+        return false;
+      }
 
       return coarsePermission == PackageManager.PERMISSION_GRANTED
         || finePermission == PackageManager.PERMISSION_GRANTED;
     }
   }
 
-  private void checkFinePermission(int finePermission) {
+  private boolean checkFinePermission(int finePermission) {
     if (finePermission != PackageManager.PERMISSION_GRANTED) {
       try {
         throw new Exception(MISSING_FINE_PERMISSION);
       } catch (Exception exception) {
         Log.e("Permission Exception", exception.getMessage());
       }
+
+      return true;
     }
+
+    return false;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -286,26 +286,19 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
     if (Build.VERSION.SDK_INT >= API_LEVEL_23) {
       return PermissionsManager.areLocationPermissionsGranted(this);
     } else {
-      int coarsePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
-        Manifest.permission.ACCESS_COARSE_LOCATION);
       int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
         Manifest.permission.ACCESS_FINE_LOCATION);
 
-      if (checkFinePermission(finePermission)) {
-        return false;
-      }
-
-      return coarsePermission == PackageManager.PERMISSION_GRANTED
-        || finePermission == PackageManager.PERMISSION_GRANTED;
+      return checkFinePermission(finePermission);
     }
   }
 
   private boolean checkFinePermission(int finePermission) {
     if (finePermission != PackageManager.PERMISSION_GRANTED) {
       Log.d("Missing Permission", MISSING_FINE_PERMISSION);
-      return true;
+      return false;
     }
 
-    return false;
+    return true;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -28,8 +28,9 @@ import static com.mapbox.android.telemetry.TelemetryReceiver.TELEMETRY_RECEIVER_
 
 public class TelemetryService extends Service implements TelemetryCallback, LocationEngineListener, EventCallback {
   public static final String IS_LOCATION_ENABLER_FROM_PREFERENCES = "isLocationEnablerFromPreferences";
-  private static final String MISSING_FINE_PERMISSION = "Detected that ACCESS_FINE_LOCATION permission is missing. "
-    + "This is a required permission for Mapbox. Please add this permission back into your manifest. Thank you.";
+  private static final String MISSING_FINE_PERMISSION = "Detected that ACCESS_FINE_LOCATION permission is missing from"
+    + " the manifest. This is a required permission for Mapbox. Please add this permission back into your manifest, "
+    + "so our system can work properly";
   public static final int API_LEVEL_23 = 23;
   private LocationReceiver locationReceiver = null;
   private TelemetryReceiver telemetryReceiver = null;
@@ -301,12 +302,7 @@ public class TelemetryService extends Service implements TelemetryCallback, Loca
 
   private boolean checkFinePermission(int finePermission) {
     if (finePermission != PackageManager.PERMISSION_GRANTED) {
-      try {
-        throw new Exception(MISSING_FINE_PERMISSION);
-      } catch (Exception exception) {
-        Log.e("Permission Exception", exception.getMessage());
-      }
-
+      Log.d("Missing Permission", MISSING_FINE_PERMISSION);
       return true;
     }
 


### PR DESCRIPTION
Detect if `ACCESS_FINE_LOCATION` permission has been removed from the manifest and throw an exception.

Fixes https://github.com/mapbox/mapbox-events-android/issues/222