### PR TITLE
PermissionChecker NPE

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -35,6 +35,8 @@ public class TelemetryService extends Service implements TelemetryCallback, Even
           + " the manifest. This is a required permission for Mapbox."
           + "Please add this permission back into your manifest, "
           + "so our system can work properly";
+  private static final String NULL_APPLICATION_CONTEXT = "MapboxTelemetry.applicationContext is null. Preventing call "
+    + "of methods that require a non-null context.";
   public static final int API_LEVEL_23 = 23;
   private static final long DEFAULT_INTERVAL_IN_MILLISECONDS = 1000L;
   private static final long DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 5;
@@ -273,12 +275,14 @@ public class TelemetryService extends Service implements TelemetryCallback, Even
     if (Build.VERSION.SDK_INT >= API_LEVEL_23) {
       return PermissionsManager.areLocationPermissionsGranted(this);
     } else {
-      if (MapboxTelemetry.applicationContext != null) {
-        int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
-          Manifest.permission.ACCESS_FINE_LOCATION);
-        return checkFinePermission(finePermission);
+      if (MapboxTelemetry.applicationContext == null) {
+        Log.d("Null Context", NULL_APPLICATION_CONTEXT);
+        return false;
       }
-      return false;
+
+      int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
+        Manifest.permission.ACCESS_FINE_LOCATION);
+      return checkFinePermission(finePermission);
     }
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryService.java
@@ -273,9 +273,12 @@ public class TelemetryService extends Service implements TelemetryCallback, Even
     if (Build.VERSION.SDK_INT >= API_LEVEL_23) {
       return PermissionsManager.areLocationPermissionsGranted(this);
     } else {
-      int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
-              Manifest.permission.ACCESS_FINE_LOCATION);
-      return checkFinePermission(finePermission);
+      if (MapboxTelemetry.applicationContext != null) {
+        int finePermission = PermissionChecker.checkSelfPermission(MapboxTelemetry.applicationContext,
+          Manifest.permission.ACCESS_FINE_LOCATION);
+        return checkFinePermission(finePermission);
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
Check if `MapboxTelemetry.applicationContext` is `null` when checking location permissions.

Fixes https://github.com/mapbox/mapbox-events-android/issues/234