### PR TITLE
Add @Nullable annotation to getLastLocation method

### DIFF
--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngineResult.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngineResult.java
@@ -1,6 +1,7 @@
 package com.mapbox.android.core.location;
 
 import android.location.Location;
+import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,6 +55,7 @@ public final class LocationEngineResult {
    * @return the most recent location {@link Location} or null.
    * @since 1.0.0
    */
+  @Nullable
   public Location getLastLocation() {
     return locations.isEmpty() ? null : locations.get(0);
   }


### PR DESCRIPTION
As per @yunikkk 's suggestion - adding `@Nullable` annotation to `LocationEngineResult#getLastLocation()` method