### PR TITLE
Fix crash due to null context reference in LocationBroadcastReceiver

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/BluetoothAudioType.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/BluetoothAudioType.java
@@ -14,13 +14,10 @@ class BluetoothAudioType implements AudioTypeResolver {
 
   @Override
   public String obtainAudioType(Context context) {
-    AudioManager audioManager = (AudioManager) MapboxTelemetry.applicationContext
-      .getSystemService(Context.AUDIO_SERVICE);
-
-    if (audioManager.isBluetoothScoOn()) {
-      return BLUETOOTH;
-    } else {
-      return chain.obtainAudioType(context);
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager == null) {
+      return "unknown";
     }
+    return audioManager.isBluetoothScoOn() ? BLUETOOTH : chain.obtainAudioType(context);
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/HeadphonesAudioType.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/HeadphonesAudioType.java
@@ -14,13 +14,10 @@ class HeadphonesAudioType implements AudioTypeResolver {
 
   @Override
   public String obtainAudioType(Context context) {
-    AudioManager audioManager = (AudioManager) MapboxTelemetry.applicationContext
-      .getSystemService(Context.AUDIO_SERVICE);
-
-    if (audioManager.isWiredHeadsetOn()) {
-      return HEADPHONES;
-    } else {
-      return chain.obtainAudioType(context);
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager == null) {
+      return "unknown";
     }
+    return audioManager.isWiredHeadsetOn() ? HEADPHONES : chain.obtainAudioType(context);
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
@@ -33,7 +33,7 @@ class LocationEvent extends Event implements Parcelable {
   @SerializedName("horizontalAccuracy")
   private Float accuracy = null;
 
-  LocationEvent(String sessionId, double latitude, double longitude) {
+  LocationEvent(String sessionId, double latitude, double longitude, String applicationState) {
     this.event = LOCATION;
     this.created = TelemetryUtils.obtainCurrentDate();
     this.source = SOURCE_MAPBOX;
@@ -41,7 +41,7 @@ class LocationEvent extends Event implements Parcelable {
     this.latitude = latitude;
     this.longitude = longitude;
     this.operatingSystem = OPERATING_SYSTEM;
-    this.applicationState = TelemetryUtils.obtainApplicationState();
+    this.applicationState = applicationState;
   }
 
   @Override

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationMapper.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationMapper.java
@@ -14,8 +14,8 @@ class LocationMapper {
     sessionIdentifier = new SessionIdentifier();
   }
 
-  LocationEvent from(Location location) {
-    LocationEvent locationEvent = createLocationEvent(location);
+  LocationEvent from(Location location, String applicationState) {
+    LocationEvent locationEvent = createLocationEvent(location, applicationState);
     return locationEvent;
   }
 
@@ -23,13 +23,12 @@ class LocationMapper {
     this.sessionIdentifier = sessionIdentifier;
   }
 
-  private LocationEvent createLocationEvent(Location location) {
+  private LocationEvent createLocationEvent(Location location, String applicationState) {
     String sessionId = sessionIdentifier.getSessionId();
-
     double latitudeScaled = round(location.getLatitude());
     double longitudeScaled = round(location.getLongitude());
     double longitudeWrapped = wrapLongitude(longitudeScaled);
-    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped);
+    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped, applicationState);
     addAltitudeIfPresent(location, locationEvent);
     addAccuracyIfPresent(location, locationEvent);
     return locationEvent;

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationReceiver.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationReceiver.java
@@ -27,7 +27,7 @@ class LocationReceiver extends BroadcastReceiver {
     if (ON_LOCATION_INTENT_EXTRA.equals(locationReceived)) {
       ArrayList<Location> locations = intent.getParcelableArrayListExtra(LocationManager.KEY_LOCATION_CHANGED);
       for (Location location: locations) {
-        sendEvent(location);
+        sendEvent(location, context);
       }
     }
   }
@@ -51,13 +51,13 @@ class LocationReceiver extends BroadcastReceiver {
     locationMapper.updateSessionIdentifier(sessionIdentifier);
   }
 
-  private boolean sendEvent(Location location) {
+  private boolean sendEvent(Location location, Context context) {
     if (isThereAnyNaN(location) || isThereAnyInfinite(location)) {
       return false;
     }
 
     LocationMapper obtainLocationEvent = obtainLocationMapper();
-    LocationEvent locationEvent = obtainLocationEvent.from(location);
+    LocationEvent locationEvent = obtainLocationEvent.from(location, TelemetryUtils.obtainApplicationState(context));
     callback.onEventReceived(locationEvent);
     return true;
   }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapClickEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapClickEvent.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -40,9 +41,16 @@ class MapClickEvent extends Event implements Parcelable {
     this.longitude = mapState.getLongitude();
     this.zoom = mapState.getZoom();
     this.created = TelemetryUtils.obtainCurrentDate();
-    this.batteryLevel = TelemetryUtils.obtainBatteryLevel();
-    this.pluggedIn = TelemetryUtils.isPluggedIn();
-    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType();
+    this.batteryLevel = 0;
+    this.pluggedIn = false;
+    this.cellularNetworkType = "";
+  }
+
+  MapClickEvent setDeviceInfo(Context context) {
+    this.batteryLevel = TelemetryUtils.obtainBatteryLevel(context);
+    this.pluggedIn = TelemetryUtils.isPluggedIn(context);
+    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType(context);
+    return this;
   }
 
   @Override

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapDragendEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapDragendEvent.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -37,9 +38,15 @@ class MapDragendEvent extends Event implements Parcelable {
     this.longitude = mapState.getLongitude();
     this.zoom = mapState.getZoom();
     this.created = TelemetryUtils.obtainCurrentDate();
-    this.batteryLevel = TelemetryUtils.obtainBatteryLevel();
-    this.pluggedIn = TelemetryUtils.isPluggedIn();
-    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType();
+    this.batteryLevel = 0;
+    this.pluggedIn = false;
+    this.cellularNetworkType = "";
+  }
+
+  MapDragendEvent setDeviceInfo(Context context) {
+    this.batteryLevel = TelemetryUtils.obtainBatteryLevel(context);
+    this.pluggedIn = TelemetryUtils.isPluggedIn(context);
+    return this;
   }
 
   @Override

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapEventFactory.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapEventFactory.java
@@ -89,8 +89,7 @@ public class MapEventFactory {
   }
 
   private MapClickEvent buildMapClickEvent(MapState mapState) {
-    MapClickEvent mapClickEvent = new MapClickEvent(mapState);
-
+    MapClickEvent mapClickEvent = new MapClickEvent(mapState).setDeviceInfo(MapboxTelemetry.applicationContext);
     mapClickEvent.setOrientation(obtainOrientation(MapboxTelemetry.applicationContext));
     mapClickEvent.setCarrier(obtainCellularCarrier(MapboxTelemetry.applicationContext));
     mapClickEvent.setWifi(obtainConnectedToWifi(MapboxTelemetry.applicationContext));
@@ -99,8 +98,7 @@ public class MapEventFactory {
   }
 
   private MapDragendEvent buildMapDragendEvent(MapState mapState) {
-    MapDragendEvent mapDragendEvent = new MapDragendEvent(mapState);
-
+    MapDragendEvent mapDragendEvent = new MapDragendEvent(mapState).setDeviceInfo(MapboxTelemetry.applicationContext);
     mapDragendEvent.setOrientation(obtainOrientation(MapboxTelemetry.applicationContext));
     mapDragendEvent.setCarrier(obtainCellularCarrier(MapboxTelemetry.applicationContext));
     mapDragendEvent.setWifi(obtainConnectedToWifi(MapboxTelemetry.applicationContext));
@@ -163,14 +161,12 @@ public class MapEventFactory {
 
   private MapLoadEvent buildMapLoadEvent() {
     String userId = TelemetryUtils.retrieveVendorId();
-    MapLoadEvent mapLoadEvent = new MapLoadEvent(userId);
-
+    MapLoadEvent mapLoadEvent = new MapLoadEvent(userId).setDeviceInfo(MapboxTelemetry.applicationContext);
     mapLoadEvent.setOrientation(obtainOrientation(MapboxTelemetry.applicationContext));
     mapLoadEvent.setAccessibilityFontScale(obtainAccessibilityFontScaleSize(MapboxTelemetry.applicationContext));
     mapLoadEvent.setCarrier(obtainCellularCarrier(MapboxTelemetry.applicationContext));
     mapLoadEvent.setResolution(obtainDisplayDensity(MapboxTelemetry.applicationContext));
     mapLoadEvent.setWifi(obtainConnectedToWifi(MapboxTelemetry.applicationContext));
-
     return mapLoadEvent;
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapLoadEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapLoadEvent.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.content.Context;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -47,9 +48,16 @@ class MapLoadEvent extends Event implements Parcelable {
     this.operatingSystem = OPERATING_SYSTEM;
     this.created = TelemetryUtils.obtainCurrentDate();
     this.userId = userId;
-    this.batteryLevel = TelemetryUtils.obtainBatteryLevel();
-    this.pluggedIn = TelemetryUtils.isPluggedIn();
-    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType();
+    this.batteryLevel = 0;
+    this.pluggedIn = false;
+    this.cellularNetworkType = "";
+  }
+
+  MapLoadEvent setDeviceInfo(Context context) {
+    this.batteryLevel = TelemetryUtils.obtainBatteryLevel(context);
+    this.pluggedIn = TelemetryUtils.isPluggedIn(context);
+    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType(context);
+    return this;
   }
 
   @Override

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -108,7 +108,8 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   @Override
   public void onFullQueue(List<Event> fullQueue) {
     TelemetryEnabler.State telemetryState = telemetryEnabler.obtainTelemetryState();
-    if (TelemetryEnabler.State.ENABLED.equals(telemetryState) && !TelemetryUtils.adjustWakeUpMode()) {
+    if (TelemetryEnabler.State.ENABLED.equals(telemetryState)
+      && !TelemetryUtils.adjustWakeUpMode(applicationContext)) {
       sendEventsIfPossible(fullQueue);
     }
   }
@@ -557,7 +558,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private boolean unbindServiceConnection() {
-    if (TelemetryUtils.isServiceRunning(TelemetryService.class)) {
+    if (TelemetryUtils.isServiceRunning(TelemetryService.class, applicationContext)) {
       applicationContext.unbindService(serviceConnection);
       return true;
     }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationMetadata.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.content.Context;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -76,19 +77,30 @@ public class NavigationMetadata implements Parcelable {
     this.device = Build.MODEL;
     this.locationEngine = locationEngine;
     this.absoluteDistanceToDestination = absoluteDistanceToDestination;
-    this.volumeLevel = NavigationUtils.obtainVolumeLevel();
-    this.batteryLevel = TelemetryUtils.obtainBatteryLevel();
-    this.screenBrightness = NavigationUtils.obtainScreenBrightness();
-    this.batteryPluggedIn = TelemetryUtils.isPluggedIn();
-    this.connectivity = TelemetryUtils.obtainCellularNetworkType();
-    this.audioType = NavigationUtils.obtainAudioType();
-    this.applicationState = TelemetryUtils.obtainApplicationState();
+    this.volumeLevel = 0;
+    this.batteryLevel = 0;
+    this.screenBrightness = 0;
+    this.batteryPluggedIn = false;
+    this.connectivity = "";
+    this.audioType = "";
+    this.applicationState = "";
     this.tripIdentifier = tripIdentifier;
     this.legIndex = legIndex;
     this.legCount = legCount;
     this.stepIndex = stepIndex;
     this.stepCount = stepCount;
     this.totalStepCount = totalStepCount;
+  }
+
+  NavigationMetadata setDeviceInfo(Context context) {
+    this.volumeLevel = NavigationUtils.obtainVolumeLevel(context);
+    this.batteryLevel = TelemetryUtils.obtainBatteryLevel(context);
+    this.screenBrightness = NavigationUtils.obtainScreenBrightness(context);
+    this.batteryPluggedIn = TelemetryUtils.isPluggedIn(context);
+    this.connectivity = TelemetryUtils.obtainCellularNetworkType(context);
+    this.audioType = NavigationUtils.obtainAudioType(context);
+    this.applicationState = TelemetryUtils.obtainApplicationState(context);
+    return this;
   }
 
   public void setCreated(Date created) {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationState.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationState.java
@@ -1,5 +1,7 @@
 package com.mapbox.android.telemetry;
 
+import android.content.Context;
+
 public class NavigationState {
   private NavigationMetadata navigationMetadata;
   private NavigationStepMetadata navigationStepMetadata;
@@ -9,8 +11,13 @@ public class NavigationState {
   private FeedbackEventData feedbackEventData;
   private FeedbackData feedbackData;
 
+  @Deprecated
   public NavigationState(NavigationMetadata navigationMetadata) {
     this.navigationMetadata = navigationMetadata;
+  }
+
+  public static NavigationState create(NavigationMetadata navigationMetadata, Context context) {
+    return new NavigationState(navigationMetadata.setDeviceInfo(context));
   }
 
   NavigationMetadata getNavigationMetadata() {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/NavigationUtils.java
@@ -9,34 +9,30 @@ class NavigationUtils {
   private static final double SCREEN_BRIGHTNESS_MAX = 255.0;
   private static final int BRIGHTNESS_EXCEPTION_VALUE = -1;
 
-  static int obtainVolumeLevel() {
-    AudioManager audioManager = (AudioManager) MapboxTelemetry.applicationContext
-      .getSystemService(Context.AUDIO_SERVICE);
-
+  static int obtainVolumeLevel(Context context) {
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
     return (int) Math.floor(PERCENT_NORMALIZER * audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
       / audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
   }
 
-  static int obtainScreenBrightness() {
+  static int obtainScreenBrightness(Context context) {
     int screenBrightness;
     try {
-      screenBrightness = android.provider.Settings.System.getInt(
-        MapboxTelemetry.applicationContext.getContentResolver(),
+      screenBrightness = android.provider.Settings.System.getInt(context.getContentResolver(),
         android.provider.Settings.System.SCREEN_BRIGHTNESS);
 
       screenBrightness = calculateScreenBrightnessPercentage(screenBrightness);
     } catch (Settings.SettingNotFoundException exception) {
       screenBrightness = BRIGHTNESS_EXCEPTION_VALUE;
     }
-
     return screenBrightness;
   }
 
-  static String obtainAudioType() {
+  static String obtainAudioType(Context context) {
     AudioTypeChain audioTypeChain = new AudioTypeChain();
     AudioTypeResolver setupChain = audioTypeChain.setup();
 
-    return setupChain.obtainAudioType(MapboxTelemetry.applicationContext);
+    return setupChain.obtainAudioType(context);
   }
 
   private static int calculateScreenBrightnessPercentage(int screenBrightness) {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/SchedulerFlusherFactory.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/SchedulerFlusherFactory.java
@@ -1,6 +1,5 @@
 package com.mapbox.android.telemetry;
 
-
 import android.app.AlarmManager;
 import android.content.Context;
 
@@ -13,7 +12,7 @@ class SchedulerFlusherFactory {
   SchedulerFlusherFactory(Context context, AlarmReceiver alarmReceiver) {
     this.context = context;
     this.alarmReceiver = alarmReceiver;
-    checkUpdatePeriod();
+    checkUpdatePeriod(context);
   }
 
   SchedulerFlusher supply() {
@@ -27,8 +26,8 @@ class SchedulerFlusherFactory {
     // }
   }
 
-  private void checkUpdatePeriod() {
-    if (TelemetryUtils.adjustWakeUpMode()) {
+  private void checkUpdatePeriod(Context context) {
+    if (TelemetryUtils.adjustWakeUpMode(context)) {
       flushingPeriod = 600 * 1000;
     }
   }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/SpeakerAudioType.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/SpeakerAudioType.java
@@ -14,13 +14,10 @@ class SpeakerAudioType implements AudioTypeResolver {
 
   @Override
   public String obtainAudioType(Context context) {
-    AudioManager audioManager = (AudioManager) MapboxTelemetry.applicationContext
-      .getSystemService(Context.AUDIO_SERVICE);
-
-    if (audioManager.isSpeakerphoneOn()) {
-      return SPEAKER;
-    } else {
-      return chain.obtainAudioType(context);
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager == null) {
+      return "unknown";
     }
+    return audioManager.isSpeakerphoneOn() ? SPEAKER : chain.obtainAudioType(context);
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
@@ -11,6 +11,9 @@ import java.util.Map;
 
 import static com.mapbox.android.telemetry.TelemetryUtils.obtainSharedPreferences;
 
+/**
+ * Do not use this class outside of activity!!!
+ */
 public class TelemetryEnabler {
   public enum State {
     ENABLED, DISABLED

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
@@ -32,7 +32,7 @@ public class LocationEventTest {
   private Event obtainALocationEvent() {
     float aLatitude = 40.416775f;
     float aLongitude = -3.703790f;
-    return new LocationEvent("anySessionId", aLatitude, aLongitude);
+    return new LocationEvent("anySessionId", aLatitude, aLongitude, "");
   }
 
   private void setupMockedContext() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationMapperTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationMapperTest.java
@@ -1,14 +1,11 @@
 package com.mapbox.android.telemetry;
 
-import android.app.ActivityManager;
-import android.content.Context;
 import android.location.Location;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -16,115 +13,81 @@ public class LocationMapperTest {
 
   @Test
   public void checksLocationEventNameMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals("location", actualLocationEvent.getEvent());
   }
 
   @Test
   public void checksLocationEventSourceMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
     assertEquals("mapbox", actualLocationEvent.getSource());
   }
 
   @Test
   public void checksLocationEventLatitudeMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLatitude()).thenReturn(51.39430732403739);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals(51.3943073, actualLocationEvent.getLatitude(), 0);
   }
 
   @Test
   public void checksLocationEventLongitudeMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(-147.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals(-147.7322583, actualLocationEvent.getLongitude(), 0);
   }
 
   @Test
   public void checksLocationEventOperatingSystemMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
     assertTrue(actualLocationEvent.getOperatingSystem().startsWith("Android - "));
   }
 
   @Test
   public void checksLocationEventWithAltitudeMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.hasAltitude()).thenReturn(true);
     when(mockedLocation.getAltitude()).thenReturn(23.43);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals(23.0, actualLocationEvent.getAltitude(), 0);
   }
 
   @Test
   public void checksLocationEventWithAccuracyMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.hasAccuracy()).thenReturn(true);
     when(mockedLocation.getAccuracy()).thenReturn(1.9f);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals(2.0, actualLocationEvent.getAccuracy(), 0);
   }
 
   @Test
   public void checksLocationEventWithOverMaxLongitudeMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(187.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
     assertEquals(-172.2677417, actualLocationEvent.getLongitude(), 0);
   }
 
   @Test
   public void checksLocationEventWithUnderMinLongitudeMapping() throws Exception {
-    setupMockedContext();
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(-187.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation);
-
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
     assertEquals(172.2677417, actualLocationEvent.getLongitude(), 0);
-  }
-
-  private void setupMockedContext() {
-    Context mockedContext = mock(Context.class);
-    MapboxTelemetry.applicationContext = mockedContext;
-    ActivityManager mockedActivityManager = mock(ActivityManager.class, RETURNS_DEEP_STUBS);
-    when(mockedContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(mockedActivityManager);
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SerializerTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SerializerTest.java
@@ -23,14 +23,13 @@ public class SerializerTest {
 
   @Test
   public void checkArriveSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
       3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "AndroidLocationEngine", 50,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
     metadata.setBatteryLevel(50);
-    NavigationState navigationState = new NavigationState(metadata);
 
     NavigationArriveEvent navigationArriveEvent = new NavigationArriveEvent(navigationState);
     GsonBuilder gsonBuilder = new GsonBuilder();
@@ -57,14 +56,13 @@ public class SerializerTest {
 
   @Test
   public void checkDepartSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
       3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "AndroidLocationEngine", 50,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
     metadata.setBatteryLevel(50);
-    NavigationState navigationState = new NavigationState(metadata);
 
     NavigationDepartEvent navigationDepartEvent = new NavigationDepartEvent(navigationState);
 
@@ -93,7 +91,6 @@ public class SerializerTest {
 
   @Test
   public void checkCancelSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
       180, "sdkIdentifier", "sdkVersion", 3, "sessionID", 10.5,
@@ -101,13 +98,13 @@ public class SerializerTest {
       "AndroidLocationEngine", 50,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
-    metadata.setBatteryLevel(50);
 
     NavigationCancelData navigationCancelData = new NavigationCancelData();
     navigationCancelData.setComment("Test");
     navigationCancelData.setRating(75);
 
-    NavigationState navigationState = new NavigationState(metadata);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
+    metadata.setBatteryLevel(50);
     navigationState.setNavigationCancelData(navigationCancelData);
 
     NavigationCancelEvent navigationCancelEvent = new NavigationCancelEvent(navigationState);
@@ -136,13 +133,11 @@ public class SerializerTest {
 
   @Test
   public void checkFeedbackSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22, 180, "sdkIdentifier", "sdkVersion",
       3, "sessionID", 10.5, 15.67, "geometry", "profile", false, "AndroidLocationEngine", 50,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
-    metadata.setBatteryLevel(50);
     FeedbackEventData navigationFeedbackData = new FeedbackEventData("userId", "general",
       "unknown");
     FeedbackData feedbackData = new FeedbackData();
@@ -152,7 +147,8 @@ public class SerializerTest {
     locationsAfter[0] = mock(Location.class);
     NavigationLocationData navigationLocationData = new NavigationLocationData(locationsBefore, locationsAfter);
 
-    NavigationState navigationState = new NavigationState(metadata);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
+    metadata.setBatteryLevel(50);
     navigationState.setNavigationLocationData(navigationLocationData);
     navigationState.setFeedbackEventData(navigationFeedbackData);
     navigationState.setFeedbackData(feedbackData);
@@ -185,7 +181,6 @@ public class SerializerTest {
 
   @Test
   public void checkRerouteSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
       180, "sdkIdent", "sdkversion", 3, "sessionID", 10.5,
@@ -193,7 +188,6 @@ public class SerializerTest {
       "MockLocationEngine", 1300,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
-    metadata.setBatteryLevel(50);
     NavigationNewData navigationNewData = new NavigationNewData(100, 750,
       "mewGeometry");
     NavigationRerouteData navigationRerouteData = new NavigationRerouteData(navigationNewData, 12000);
@@ -218,7 +212,9 @@ public class SerializerTest {
     Location[] locationsAfter = new Location[1];
     NavigationLocationData navigationLocationData = new NavigationLocationData(locationsBefore, locationsAfter);
 
-    NavigationState navigationState = new NavigationState(metadata);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
+    metadata.setBatteryLevel(50);
+
     navigationState.setNavigationLocationData(navigationLocationData);
     navigationState.setNavigationRerouteData(navigationRerouteData);
     navigationState.setFeedbackData(feedbackData);
@@ -257,7 +253,6 @@ public class SerializerTest {
 
   @Test
   public void checkFasterRouteSerializing() throws Exception {
-    setupMockedContext();
     Date testDate = new Date();
     NavigationMetadata metadata = new NavigationMetadata(testDate, 13, 22,
       180, "sdkIdent", "sdkversion", 3, "sessionID", 10.5,
@@ -265,7 +260,6 @@ public class SerializerTest {
       "MockLocationEngine", 1300,
       "tripIdentifier", 3, 5, 2, 3, 10);
     metadata.setCreated(testDate);
-    metadata.setBatteryLevel(50);
     NavigationNewData navigationNewData = new NavigationNewData(100, 750,
       "mewGeometry");
     NavigationRerouteData navigationRerouteData = new NavigationRerouteData(navigationNewData, 12000);
@@ -284,7 +278,8 @@ public class SerializerTest {
     navigationStepMetadata.setDistanceRemaining(250);
     navigationStepMetadata.setDurationRemaining(2200);
 
-    NavigationState navigationState = new NavigationState(metadata);
+    NavigationState navigationState = NavigationState.create(metadata, getMockedContext());
+    metadata.setBatteryLevel(50);
     navigationState.setNavigationRerouteData(navigationRerouteData);
     navigationState.setNavigationStepMetadata(navigationStepMetadata);
 
@@ -318,14 +313,14 @@ public class SerializerTest {
     assertEquals(expectedJson, payload);
   }
 
-  private void setupMockedContext() {
+  private Context getMockedContext() {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
-    MapboxTelemetry.applicationContext = mockedContext;
     AudioManager mockedAudioManager = mock(AudioManager.class, RETURNS_DEEP_STUBS);
     when(mockedContext.getSystemService(Context.AUDIO_SERVICE)).thenReturn(mockedAudioManager);
     TelephonyManager mockedTelephonyManager = mock(TelephonyManager.class, RETURNS_DEEP_STUBS);
     when(mockedContext.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(mockedTelephonyManager);
     ActivityManager mockedActivityManager = mock(ActivityManager.class, RETURNS_DEEP_STUBS);
     when(mockedContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(mockedActivityManager);
+    return mockedContext;
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
@@ -28,7 +28,7 @@ public class TelemetryClientLocationEventTest extends MockWebServerTest {
     TelemetryClient telemetryClient = obtainATelemetryClient("anyAccessToken", "anyUserAgent");
     double aLatitude = 40.416775;
     double aLongitude = -3.703790;
-    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude);
+    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude, "");
     List<Event> theLocationEvent = obtainEvents(aLocationEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();


### PR DESCRIPTION
Fix crashes and introduce temporary refactor for `TelemetryUtils` class until libtelemetry is fully rewritten. 
Although this change is backwards compatible, it impacts @mapbox/navigation-android. Specifically, `NavigationState` class, which public constructor became deprecated.
```
@Deprecated
public NavigationState(NavigationMetadata navigationMetadata) {
  this.navigationMetadata = navigationMetadata;
}
```
the new recommended way of instantiating this class is via this static factory:
```
public static NavigationState create(NavigationMetadata navigationMetadata, Context context) {
  return new NavigationState(navigationMetadata.setDeviceInfo(context));
}
``` 
The motivation behind this change is extracting `Context` as much as possible from utility class. What it means for navigation sdk: if switch from public constructor to static factory is not happening, we will be loosing all device info fields, such as `plugged`, `networkType` and etc.
@Guardiola31337 @danesfeder  please let me know if i need to create a ticket in android nav repo to track this change.

Stack trace of this crash:
```
Crashed: main
       at com.mapbox.android.telemetry.TelemetryUtils.obtainApplicationState(TelemetryUtils.java:100)
       at com.mapbox.android.telemetry.LocationEvent.(LocationEvent.java:44)
       at com.mapbox.android.telemetry.LocationMapper.createLocationEvent(LocationMapper.java:32)
       at com.mapbox.android.telemetry.LocationMapper.from(LocationMapper.java:18)
       at com.mapbox.android.telemetry.LocationReceiver.sendEvent(LocationReceiver.java:47)
       at com.mapbox.android.telemetry.LocationReceiver.onReceive(LocationReceiver.java:26)
       at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:311)
       at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:47)
       at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:120)
       at android.os.Handler.dispatchMessage(Handler.java:105)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6938)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)
```