### PR TITLE
Fix missed cellNetworkType field in map drag event

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapDragendEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapDragendEvent.java
@@ -46,6 +46,7 @@ class MapDragendEvent extends Event implements Parcelable {
   MapDragendEvent setDeviceInfo(Context context) {
     this.batteryLevel = TelemetryUtils.obtainBatteryLevel(context);
     this.pluggedIn = TelemetryUtils.isPluggedIn(context);
+    this.cellularNetworkType = TelemetryUtils.obtainCellularNetworkType(context);
     return this;
   }
 


### PR DESCRIPTION
Address code review comment: https://github.com/mapbox/mapbox-events-android/pull/272/files#r230745352

Thanks @danesfeder for catching it!