### PR TITLE
Add codecov badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/mapbox/mapbox-events-android/tree/master.svg?style=svg&circle-token=b206c88b942901329c5d8632a9e5d1b8cd501a61)](https://circleci.com/gh/mapbox/mapbox-events-android/tree/master)
+[![codecov](https://codecov.io/gh/mapbox/mapbox-events-android/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/mapbox-events-android)
 
 # Mapbox Mobile Events
 


### PR DESCRIPTION
After #262 we should be posting coverage data to codecov.io for per commit/PR tracking. And PRs that drop coverage should fail their checks. This PR adds a friendly codecov badge, but the real motivation of this PR is to test that codecov is working: it should report the difference in coverage from this PR vs the master branch (which should be 0% of course given no code changes).