### PR TITLE
Handle IndexOutOfBounds for Cert Blacklist retrieval

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
@@ -80,7 +80,7 @@ class CertificateBlacklist implements Callback {
         try {
           blacklist = obtainBlacklistContents(file);
           blacklist.remove(BLACKLIST_HEAD);
-        } catch (IOException exception) {
+        } catch (IOException | IndexOutOfBoundsException exception) {
           logger.error(RETRIEVE_BLACKLIST_FAIL, exception.getMessage());
         }
       }


### PR DESCRIPTION
I saw this come up in our Crashlytics logs after upgrading to the most recent version. Doesn't seem like it needs to be a fatal.