### PR TITLE
Remove jacoco from release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
             minifyEnabled false
         }
         release {
-            minifyEnabled false // Proguard complains about jacoco
+            minifyEnabled true
         }
     }
 }

--- a/liblocation/build.gradle
+++ b/liblocation/build.gradle
@@ -16,10 +16,6 @@ android {
         debug {
             testCoverageEnabled true
         }
-
-        release {
-            testCoverageEnabled true
-        }
     }
 
     lintOptions {

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -19,10 +19,6 @@ android {
         debug {
             testCoverageEnabled true
         }
-
-        release {
-            testCoverageEnabled true
-        }
     }
 
     testOptions {


### PR DESCRIPTION
Fixing proguard warnings by removing jacoco from release builds. Addresses https://github.com/mapbox/mapbox-events-android/issues/302