### PR TITLE
Resolve crash caused by removing items from empty List

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
@@ -76,7 +76,9 @@ class CertificateBlacklist implements Callback {
       if (file.exists()) {
         try {
           blacklist = obtainBlacklistContents(file);
-          blacklist.remove(BLACKLIST_HEAD);
+          if (blacklist.size() > 0) {
+            blacklist.remove(BLACKLIST_HEAD);
+          }
         } catch (IOException | IndexOutOfBoundsException exception) {
           Log.e(LOG_TAG, exception.getMessage());
         }


### PR DESCRIPTION
blacklist could be empty if there is an exception in `obtainBlacklistContents` method, so add a check to fix it.