### PR TITLE
Enable event creation outside of telem sdk

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/Event.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/Event.java
@@ -7,13 +7,14 @@ import java.util.EnumSet;
 
 public abstract class Event implements Parcelable {
 
+  @Deprecated
   public enum Type {
     TURNSTILE,
     MAP_LOAD, MAP_CLICK, MAP_DRAGEND,
     OFFLINE_DOWNLOAD_START, OFFLINE_DOWNLOAD_COMPLETE,
     LOCATION,
     NAV_DEPART, NAV_ARRIVE, NAV_CANCEL, NAV_REROUTE, NAV_FEEDBACK, NAV_FASTER_ROUTE,
-    VIS_GENERAL, VIS_ATTACHMENT, VIS_OBJ_DETECTION
+    VIS_GENERAL, VIS_ATTACHMENT, VIS_OBJ_DETECTION, NO_OP
   }
 
   static EnumSet<Type> mapGestureEventTypes = EnumSet.of(Type.MAP_CLICK, Type.MAP_DRAGEND);
@@ -21,5 +22,7 @@ public abstract class Event implements Parcelable {
     Type.NAV_REROUTE, Type.NAV_FEEDBACK, Type.NAV_FASTER_ROUTE);
   static EnumSet<Type> visionEventTypes = EnumSet.of(Type.VIS_GENERAL, Type.VIS_ATTACHMENT, Type.VIS_OBJ_DETECTION);
 
-  abstract Type obtainType();
+  Type obtainType() {
+    return Type.NO_OP;
+  }
 }


### PR DESCRIPTION
Remove abstract `obtainType` to enable event creation outside of telemetry sdk. This change is done with a focus on preserving current telem sdk api signatures.

An open question: since we don't have any events outside of telem sdk yet, should we remove `Parcelable` dependency before we expose it to public? Can we do it without doing a major release?

/cc @mapbox/android 