### PR TITLE
Move SendEvents logic to separate thread

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,8 @@ ext {
             gson                : '2.8.2',
             espressoVersion     : '3.0.1',
             archLifecycleVersion: "1.1.0",
-            assertJ             : "3.11.1"
+            assertJ             : "3.11.1",
+            archWorkManager     : "1.0.0-beta01"
     ]
 
     pluginVersion = [
@@ -34,6 +35,7 @@ ext {
             //architecture components
             archLifecycleExtensions: "android.arch.lifecycle:extensions:${version.archLifecycleVersion}",
             archLifecycleCompiler  : "android.arch.lifecycle:compiler:${version.archLifecycleVersion}",
+            archWorkManager        : "android.arch.work:work-runtime:${version.archWorkManager}",
 
             // okhttp
             okhttp3                : "com.squareup.okhttp3:okhttp:${version.okhttp3}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
             espressoVersion     : '3.0.1',
             archLifecycleVersion: "1.1.0",
             assertJ             : "3.11.1",
-            archWorkManager     : "1.0.0-beta01"
+            workVersion         : "1.0.0-beta01"
     ]
 
     pluginVersion = [
@@ -35,7 +35,7 @@ ext {
             //architecture components
             archLifecycleExtensions: "android.arch.lifecycle:extensions:${version.archLifecycleVersion}",
             archLifecycleCompiler  : "android.arch.lifecycle:compiler:${version.archLifecycleVersion}",
-            archWorkManager        : "android.arch.work:work-runtime:${version.archWorkManager}",
+            archWorkManager        : "android.arch.work:work-runtime:${version.workVersion}",
 
             // okhttp
             okhttp3                : "com.squareup.okhttp3:okhttp:${version.okhttp3}",

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation dependenciesList.okhttp3
     implementation dependenciesList.gson
     implementation dependenciesList.archLifecycleExtensions
+    implementation dependenciesList.archWorkManager
 
     annotationProcessor dependenciesList.archLifecycleCompiler
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -337,10 +337,15 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
     }
   }
 
-  private void sendEventsIfPossible(List<Event> events) {
-    if (isNetworkConnected()) {
-      sendEvents(events);
-    }
+  private void sendEventsIfPossible(final List<Event> events) {
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        if (isNetworkConnected()) {
+          sendEvents(events);
+        }
+      }
+    }).start();
   }
 
   private boolean isNetworkConnected() {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -338,14 +338,9 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   }
 
   private void sendEventsIfPossible(final List<Event> events) {
-    new Thread(new Runnable() {
-      @Override
-      public void run() {
-        if (isNetworkConnected()) {
-          sendEvents(events);
-        }
-      }
-    }).start();
+    if (isNetworkConnected()) {
+      sendEvents(events);
+    }
   }
 
   private boolean isNetworkConnected() {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -55,6 +57,9 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   private CopyOnWriteArraySet<AttachmentListener> attachmentListeners = null;
   private final ConfigurationClient configurationClient;
   static Context applicationContext = null;
+
+  //test
+  private WorkManager workManager;
 
   public MapboxTelemetry(Context context, String accessToken, String userAgent) {
     initializeContext(context);
@@ -130,6 +135,7 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
   public boolean enable() {
     if (TelemetryEnabler.isEventsEnabled(applicationContext)) {
       startTelemetry();
+      setupWorkManager();
       return true;
     }
 
@@ -604,5 +610,10 @@ public class MapboxTelemetry implements FullQueueCallback, EventCallback, Servic
 
   private boolean isLollipopOrHigher() {
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+  }
+
+  private void setupWorkManager() {
+    workManager = WorkManager.getInstance();
+    workManager.enqueue(OneTimeWorkRequest.from(WorkTest.class));
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/WorkTest.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/WorkTest.java
@@ -1,0 +1,21 @@
+package com.mapbox.android.telemetry;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+public class WorkTest extends Worker {
+  public WorkTest(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+    super(context, workerParams);
+  }
+
+  @NonNull
+  @Override
+  public Result doWork() {
+    Log.e("test", "doing work....");
+    return null;
+  }
+}


### PR DESCRIPTION
After attempting to replicate an `ANR` with no results, we are moving event logic to a background thread to prevent it from holding up any foreground processes. 

This implementation keeps our current event queue working as is, but takes long running processes associated with network connection and activating our `TelemetryClient` request off of the UI thread. All non-vision events flow through `sendEventsIfPossible`, so it was the logical point to implement this change.