### PR TITLE
Additional Testing Around Blacklist and ConfigurationClient

### DIFF
--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/CertificateBlacklistInstrumentationTests.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/CertificateBlacklistInstrumentationTests.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import okhttp3.OkHttpClient;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -31,7 +32,22 @@ public class CertificateBlacklistInstrumentationTests {
   }
 
   @Test
-  public void checkBlacklistSaved() throws Exception {
+  public void checkBlacklistMalformed() {
+    List<String> oneItemList = new ArrayList<>();
+    oneItemList.add("test12345");
+    String preContent = "{\"RevokedCertKeys\" : [\"\"]}";
+    String fileContent = "{\"RevokedCertKeys\" : \"test12345\"}";
+
+    certificateBlacklist.onUpdate(preContent);
+    assertFalse(certificateBlacklist.isBlacklisted(oneItemList.get(0)));
+
+    certificateBlacklist.onUpdate(fileContent);
+
+    assertFalse(certificateBlacklist.isBlacklisted(oneItemList.get(0)));
+  }
+
+  @Test
+  public void checkBlacklistSaved() {
     List<String> oneItemList = new ArrayList<>();
     oneItemList.add("test12345");
     String fileContent = "{\"RevokedCertKeys\" : [\"test12345\"]}";

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
@@ -1,0 +1,57 @@
+package com.mapbox.android.telemetry;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class ConfigurationClientInstrumentationTest {
+  private ConfigurationClient configurationClient;
+  private static final long DAY_IN_MILLIS = 86400000;
+
+  @Before
+  public void setup() {
+    Context context = InstrumentationRegistry.getTargetContext();
+    this.configurationClient = new ConfigurationClient(context,
+      TelemetryUtils.createFullUserAgent("AnUserAgent", context), "anAccessToken", new OkHttpClient());
+  }
+
+  @Test
+  public void shouldUpdateTest() {
+    setTimeStamp(System.currentTimeMillis() - DAY_IN_MILLIS);
+    assertTrue(configurationClient.shouldUpdate());
+
+    setTimeStamp(System.currentTimeMillis());
+    assertFalse(configurationClient.shouldUpdate());
+  }
+
+  @Test
+  public void saveTimeStampTest() {
+    setTimeStamp(System.currentTimeMillis() - DAY_IN_MILLIS);
+    Call mockedCall = mock(Call.class);
+    IOException mockedException = mock(IOException.class);
+
+    configurationClient.onFailure(mockedCall, mockedException);
+
+    assertFalse(configurationClient.shouldUpdate());
+  }
+
+  private void setTimeStamp(Long milliseconds) {
+    SharedPreferences sharedPreferences =
+      TelemetryUtils.obtainSharedPreferences(InstrumentationRegistry.getTargetContext());
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    editor.putLong("mapboxConfigSyncTimestamp", milliseconds);
+    editor.apply();
+  }
+
+}

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -46,7 +47,7 @@ public class ConfigurationClientInstrumentationTest {
     assertFalse(configurationClient.shouldUpdate());
   }
 
-  private void setTimeStamp(Long milliseconds) {
+  private void setTimeStamp(long milliseconds) {
     SharedPreferences sharedPreferences =
       TelemetryUtils.obtainSharedPreferences(InstrumentationRegistry.getTargetContext());
     SharedPreferences.Editor editor = sharedPreferences.edit();

--- a/libtelemetry/src/main/AndroidManifest.xml
+++ b/libtelemetry/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application>
         <service android:name="com.mapbox.android.telemetry.TelemetryService"/>
     </application>

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
@@ -103,7 +103,7 @@ class CertificateBlacklist implements ConfigurationChangeHandler {
       JsonObject responseJson = gson.fromJson(data, JsonObject.class);
       JsonElement jsonElement = responseJson.get("RevokedCertKeys");
 
-      jsonArray = isJsonArray(jsonElement) ? gson.fromJson(jsonElement, JsonArray.class) : null;
+      jsonArray = jsonElement.isJsonArray() ? gson.fromJson(jsonElement, JsonArray.class) : null;
     } catch (JsonSyntaxException exception) {
       Log.e(LOG_TAG, exception.getMessage());
       return false;
@@ -135,9 +135,5 @@ class CertificateBlacklist implements ConfigurationChangeHandler {
     if (saveBlackList(data)) {
       retrieveBlackList(context.getFilesDir(), true);
     }
-  }
-
-  private static boolean isJsonArray(JsonElement element) {
-    return element instanceof JsonArray;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/CertificateBlacklist.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
@@ -100,7 +101,9 @@ class CertificateBlacklist implements ConfigurationChangeHandler {
     JsonArray jsonArray;
     try {
       JsonObject responseJson = gson.fromJson(data, JsonObject.class);
-      jsonArray = responseJson.getAsJsonArray("RevokedCertKeys");
+      JsonElement jsonElement = responseJson.get("RevokedCertKeys");
+
+      jsonArray = isJsonArray(jsonElement) ? gson.fromJson(jsonElement, JsonArray.class) : null;
     } catch (JsonSyntaxException exception) {
       Log.e(LOG_TAG, exception.getMessage());
       return false;
@@ -132,5 +135,9 @@ class CertificateBlacklist implements ConfigurationChangeHandler {
     if (saveBlackList(data)) {
       retrieveBlackList(context.getFilesDir(), true);
     }
+  }
+
+  private static boolean isJsonArray(JsonElement element) {
+    return element instanceof JsonArray;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/ConfigurationClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/ConfigurationClient.java
@@ -90,7 +90,7 @@ class ConfigurationClient implements Callback {
     }
 
     for (final ConfigurationChangeHandler handler: handlers) {
-      handler.onUpdate(body.string());
+      handlerNullCheck(handler).onUpdate(body.string());
     }
   }
 
@@ -126,5 +126,18 @@ class ConfigurationClient implements Callback {
     }
 
     return COM_CONFIG_ENDPOINT;
+  }
+
+  private ConfigurationChangeHandler handlerNullCheck(ConfigurationChangeHandler changeHandler) {
+    if (changeHandler == null) {
+      return new ConfigurationChangeHandler() {
+        @Override
+        public void onUpdate(String data) {
+
+        }
+      };
+    }
+
+    return changeHandler;
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/ConfigurationClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/ConfigurationClient.java
@@ -90,7 +90,9 @@ class ConfigurationClient implements Callback {
     }
 
     for (final ConfigurationChangeHandler handler: handlers) {
-      handlerNullCheck(handler).onUpdate(body.string());
+      if (handler != null) {
+        handler.onUpdate(body.string());
+      }
     }
   }
 
@@ -126,18 +128,5 @@ class ConfigurationClient implements Callback {
     }
 
     return COM_CONFIG_ENDPOINT;
-  }
-
-  private ConfigurationChangeHandler handlerNullCheck(ConfigurationChangeHandler changeHandler) {
-    if (changeHandler == null) {
-      return new ConfigurationChangeHandler() {
-        @Override
-        public void onUpdate(String data) {
-
-        }
-      };
-    }
-
-    return changeHandler;
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
@@ -142,13 +142,13 @@ public class ConfigurationClientTest {
   }
 
   private Response getValidResponse() throws IOException {
-    Request mRequest = mock(Request.class);
+    Request request = mock(Request.class);
 
     Response.Builder builder = new Response.Builder();
     ResponseBody responseBody = mock(ResponseBody.class);
     when(responseBody.string()).thenReturn("test");
 
-    return builder.request(mRequest)
+    return builder.request(request)
       .body(responseBody)
       .protocol(Protocol.HTTP_1_1)
       .code(200)

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
@@ -101,6 +101,16 @@ public class ConfigurationClientTest {
     verify(mockedHandler, times(0)).onUpdate("test");
   }
 
+  @Test
+  public void nullHandler() throws Exception {
+    ConfigurationChangeHandler nullHandler = null;
+    configurationClient.addHandler(nullHandler);
+    Call mockedCall = mock(Call.class);
+    Response response = getValidResponse();
+
+    configurationClient.onResponse(mockedCall, response);
+  }
+
   private TelemetryClientSettings provideDefaultTelemetryClientSettings() {
     HttpUrl localUrl = obtainBaseEndpointUrl();
     SslClient sslClient = SslClient.localhost();

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
@@ -12,12 +12,18 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 
+import okhttp3.Call;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.internal.tls.SslClient;
 
@@ -26,6 +32,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ConfigurationClientTest {
@@ -70,6 +78,29 @@ public class ConfigurationClientTest {
     assertTrue(configurationClient.shouldUpdate());
   }
 
+  @Test
+  public void successResponse() throws IOException {
+    ConfigurationChangeHandler mockedHandler = mock(ConfigurationChangeHandler.class);
+    configurationClient.addHandler(mockedHandler);
+    Call mockedCall = mock(Call.class);
+    Response response = getValidResponse();
+
+    configurationClient.onResponse(mockedCall, response);
+
+    verify(mockedHandler, times(1)).onUpdate("test");
+  }
+
+  @Test
+  public void nullResponse() throws IOException {
+    ConfigurationChangeHandler mockedHandler = mock(ConfigurationChangeHandler.class);
+    configurationClient.addHandler(mockedHandler);
+    Call mockedCall = mock(Call.class);
+
+    configurationClient.onResponse(mockedCall, null);
+
+    verify(mockedHandler, times(0)).onUpdate("test");
+  }
+
   private TelemetryClientSettings provideDefaultTelemetryClientSettings() {
     HttpUrl localUrl = obtainBaseEndpointUrl();
     SslClient sslClient = SslClient.localhost();
@@ -108,5 +139,20 @@ public class ConfigurationClientTest {
     when(mockedContext.getPackageName()).thenReturn(packageName);
 
     return mockedContext;
+  }
+
+  private Response getValidResponse() throws IOException {
+    Request mRequest = mock(Request.class);
+
+    Response.Builder builder = new Response.Builder();
+    ResponseBody responseBody = mock(ResponseBody.class);
+    when(responseBody.string()).thenReturn("test");
+
+    return builder.request(mRequest)
+      .body(responseBody)
+      .protocol(Protocol.HTTP_1_1)
+      .code(200)
+      .message("success")
+      .build();
   }
 }


### PR DESCRIPTION
Add additional testing (unit and instrumentation) for Blacklist and ConfigurationClient. Goal is to increase test coverage, handle corner cases better, and prepare for wider array of testing platforms (api levels + devices).

Fixes: https://github.com/mapbox/mapbox-events-android/issues/330