### PR TITLE
Remove Unused Lifecycle Dependencies

### DIFF
--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation dependenciesList.gson
     implementation dependenciesList.supportAnnotation
     implementation (dependenciesList.archLifecycleExtensions) {
-        exclude group: 'android.arch.lifecycle', module: 'runtime'
         exclude group: 'android.arch.lifecycle', module: 'livedata'
         exclude group: 'android.arch.lifecycle', module: 'viewmodel'
         exclude group: 'android.arch.core', module: 'runtime'

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -39,7 +39,13 @@ dependencies {
     implementation dependenciesList.okhttp3
     implementation dependenciesList.gson
     implementation dependenciesList.supportAnnotation
-    implementation dependenciesList.archLifecycleExtensions
+    implementation (dependenciesList.archLifecycleExtensions) {
+        exclude group: 'android.arch.lifecycle', module: 'runtime'
+        exclude group: 'android.arch.lifecycle', module: 'livedata'
+        exclude group: 'android.arch.lifecycle', module: 'viewmodel'
+        exclude group: 'android.arch.core', module: 'common'
+        exclude group: 'android.arch.core', module: 'runtime'
+    }
 
     annotationProcessor dependenciesList.archLifecycleCompiler
 

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -43,7 +43,6 @@ dependencies {
         exclude group: 'android.arch.lifecycle', module: 'livedata'
         exclude group: 'android.arch.lifecycle', module: 'viewmodel'
         exclude group: 'android.arch.core', module: 'runtime'
-        exclude group: 'com.android.support', module: 'support-annotations'
     }
 
     annotationProcessor dependenciesList.archLifecycleCompiler

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -43,6 +43,7 @@ dependencies {
         exclude group: 'android.arch.lifecycle', module: 'livedata'
         exclude group: 'android.arch.lifecycle', module: 'viewmodel'
         exclude group: 'android.arch.core', module: 'runtime'
+        exclude group: 'com.android.support', module: 'support-annotations'
     }
 
     annotationProcessor dependenciesList.archLifecycleCompiler

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -43,7 +43,6 @@ dependencies {
         exclude group: 'android.arch.lifecycle', module: 'runtime'
         exclude group: 'android.arch.lifecycle', module: 'livedata'
         exclude group: 'android.arch.lifecycle', module: 'viewmodel'
-        exclude group: 'android.arch.core', module: 'common'
         exclude group: 'android.arch.core', module: 'runtime'
     }
 


### PR DESCRIPTION
Exclude unused dependencies associated with `LifecycleExtensions`.

Addresses: https://github.com/mapbox/mapbox-events-android/issues/273