### PR TITLE
Fix pom artifactId for libcore dependency

### DIFF
--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -128,7 +128,8 @@ afterEvaluate { project ->
 
                                 dependency {
                                     groupId dep.group
-                                    artifactId dep.name
+                                    // Since name is readonly property we can't override it
+                                    artifactId (dep.name == 'libcore' ? 'mapbox-android-core' : dep.name)
                                     version dep.version
                                     scope "compile"
 


### PR DESCRIPTION
Apps fail to resolve `libcore` due to incorrect `artifactId`. Fix is ugly but there's no better way to override project name property programmatically since it's readonly. Tested with `mavenLocal` and `app` module. 