### PR TITLE
Add null check for pending Intent

### DIFF
--- a/app/src/androidTest/java/com/mapbox/android/events/testapp/MainActivityInstrumentationTests.java
+++ b/app/src/androidTest/java/com/mapbox/android/events/testapp/MainActivityInstrumentationTests.java
@@ -1,0 +1,23 @@
+package com.mapbox.android.events.testapp;
+
+import android.app.Activity;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class MainActivityInstrumentationTests {
+  @Rule
+  public ActivityTestRule rule = new ActivityTestRule(MainActivity.class, true, true);
+
+  @Test
+  public void checkActivity() {
+    Activity activity = rule.getActivity();
+    assertNotNull(activity);
+  }
+}

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/AlarmSchedulerFlusher.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/AlarmSchedulerFlusher.java
@@ -9,8 +9,8 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.VisibleForTesting;
 
-import static com.mapbox.android.telemetry.SchedulerFlusherFactory.flushingPeriod;
 import static com.mapbox.android.telemetry.SchedulerFlusherFactory.SCHEDULER_FLUSHER_INTENT;
+import static com.mapbox.android.telemetry.SchedulerFlusherFactory.flushingPeriod;
 
 class AlarmSchedulerFlusher implements SchedulerFlusher {
   private final Context context;
@@ -53,7 +53,9 @@ class AlarmSchedulerFlusher implements SchedulerFlusher {
 
   @Override
   public void unregister() {
-    manager.cancel(pendingIntent);
+    if (pendingIntent != null) {
+      manager.cancel(pendingIntent);
+    }
     try {
       context.unregisterReceiver(receiver);
     } catch (IllegalArgumentException exception) {

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/AlarmSchedulerFlusherTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/AlarmSchedulerFlusherTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -61,7 +62,7 @@ public class AlarmSchedulerFlusherTest {
 
     theAlarmSchedulerFlusher.unregister();
 
-    verify(mockedAlarmManager, times(0)).cancel(eq(theAlarmSchedulerFlusher.obtainPendingIntent()));
+    verify(mockedAlarmManager, never()).cancel(eq(theAlarmSchedulerFlusher.obtainPendingIntent()));
     verify(mockedContext, times(1)).unregisterReceiver(mockedAlarmReceiver);
   }
 

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/AlarmSchedulerFlusherTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/AlarmSchedulerFlusherTest.java
@@ -61,7 +61,7 @@ public class AlarmSchedulerFlusherTest {
 
     theAlarmSchedulerFlusher.unregister();
 
-    verify(mockedAlarmManager, times(1)).cancel(eq(theAlarmSchedulerFlusher.obtainPendingIntent()));
+    verify(mockedAlarmManager, times(0)).cancel(eq(theAlarmSchedulerFlusher.obtainPendingIntent()));
     verify(mockedContext, times(1)).unregisterReceiver(mockedAlarmReceiver);
   }
 


### PR DESCRIPTION
Run into a crash while testing

```
java.lang.NullPointerException: cancel() called with a null PendingIntent
at android.app.AlarmManager.cancel(AlarmManager.java:916)
at com.mapbox.android.telemetry.AlarmSchedulerFlusher.unregister(AlarmSchedulerFlusher.java:56)
at com.mapbox.android.telemetry.MapboxTelemetry.stopAlarm(MapboxTelemetry.java:433)
at com.mapbox.android.telemetry.MapboxTelemetry.stopTelemetry(MapboxTelemetry.java:538)
at com.mapbox.android.telemetry.MapboxTelemetry.disable(MapboxTelemetry.java:139)
at com.mapbox.android.events.testapp.MainActivity.onDestroy(MainActivity.java:37)
```
Root cause is that PendingIntent is inited in

```
 public void register() {
    Intent alarmIntent = receiver.supplyIntent();
    pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, 0);
    IntentFilter filter = new IntentFilter(SCHEDULER_FLUSHER_INTENT);
    context.registerReceiver(receiver, filter);
  }
```
If this method is not called before destroy, the pendingIntent will be null.