### PR TITLE
Fix GoogleLocationEngine intermittent delayed updates

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     version = [
-            gmsLocation         : '15.0.1',
+            gmsLocation         : '16.0.0',
             junit               : '4.12',
             supportLibVersion   : '28.0.0',
             constraintLayout    : '1.0.2',

--- a/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngineRequest.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngineRequest.java
@@ -122,7 +122,7 @@ public class LocationEngineRequest {
     public Builder(long interval) {
       this.interval = interval;
       this.priority = PRIORITY_HIGH_ACCURACY;
-      this.displacement = 3.0f;
+      this.displacement = 0.0f;
       this.maxWaitTime = 0L;
       this.fastestInterval = 0L;
     }


### PR DESCRIPTION
Reset default `displacement` value to 0 due to potential delay with first location update on Pie that  takes 30 seconds - 1 min. We've not seen this behavior on pre-Pie api versions, so the assumption is that changes in framework were made that no longer work well with default displacement value we had tested with previously.

/cc @danesfeder @Guardiola31337 