### PR TITLE
Resolve strict mode UntaggedSocketViolation issue

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/GzipRequestInterceptor.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/GzipRequestInterceptor.java
@@ -1,6 +1,8 @@
 package com.mapbox.android.telemetry;
 
 
+import android.net.TrafficStats;
+
 import java.io.IOException;
 
 import okhttp3.Interceptor;
@@ -13,12 +15,18 @@ import okio.GzipSink;
 import okio.Okio;
 
 final class GzipRequestInterceptor implements Interceptor {
+  private static final int THREAD_ID = 10000;
 
   @Override
   public Response intercept(Interceptor.Chain chain) throws IOException {
     Request originalRequest = chain.request();
     if (originalRequest.body() == null || originalRequest.header("Content-Encoding") != null) {
       return chain.proceed(originalRequest);
+    }
+
+    if (BuildConfig.DEBUG) {
+      //Fix strict mode issue, see https://github.com/square/okhttp/issues/3537#issuecomment-431632176
+      TrafficStats.setThreadStatsTag(THREAD_ID);
     }
 
     Request compressedRequest = originalRequest.newBuilder()


### PR DESCRIPTION
Resolves #357 

There is a strict mode issue while running test app

```
StrictMode: StrictMode policy violation: android.os.strictmode.UntaggedSocketViolation: Untagged socket detected; use TrafficStats.setThreadSocketTag() to track all network usage
        at android.os.StrictMode.onUntaggedSocket(StrictMode.java:2023)
```
Root cause

Solution:
Add call TrafficStats.setThreadStatsTag(THREAD_ID); in `com.mapbox.android.telemetry.GzipRequestInterceptor.intercept`