### PR TITLE
rm full implementation

### DIFF
--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -116,9 +116,6 @@ afterEvaluate { project ->
                     // Hacking with telem pom due to bug in gradle uploadArchives task
                     if (isTelem()) {
                         def allDependencies = configurations.implementation.allDependencies
-                        if (!isLiteRelease()) {
-                            allDependencies += configurations.fullImplementation.allDependencies
-                        }
 
                         dependencies {
                             for (def dep: allDependencies) {


### PR DESCRIPTION
Build map sdk with telemetry snapshot 4.3.0 will cause the following error
```
  
 /src/platform/android/MapboxGLAndroidSDK/build.gradle: Error: All com.android.support libraries must use the exact same version specification (mixing versions can lead to runtime crashes). Found versions 28.0.0, 27.1.1. Examples include com.android.support:collections:28.0.0 and com.android.support:animated-vector-drawable:27.1.1 [GradleCompatible]
```

If we dig into the [pom file](https://oss.sonatype.org/content/repositories/snapshots/com/mapbox/mapboxsdk/mapbox-android-telemetry/4.3.0-SNAPSHOT/mapbox-android-telemetry-4.3.0-20190308.070635-24.pom)
we will find it contains `com.android.support` with version 28.0.0, while map sdk is `27.1.1`, so it will conflict.

Solution:
rm full implementation while upload archives.