### PR TITLE
Mismatched Dependency Issue 

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     version = [
             gmsLocation         : '16.0.0',
             junit               : '4.12',
-            supportLibVersion   : '28.0.0',
+            supportLibVersion   : '27.1.1',
             constraintLayout    : '1.0.2',
             mockito             : '2.11.0',
             testRunnerVersion   : '1.0.1',
@@ -51,6 +51,7 @@ ext {
             supportConstraintLayout: "com.android.support.constraint:constraint-layout:${version.constraintLayout}",
             localBroadcastManager  : "com.android.support:localbroadcastmanager:${version.supportLibVersion}",
             supportCompat          : "com.android.support:support-compat:${version.supportLibVersion}",
+            supportCoreUtils       : "com.android.support:support-core-utils:${version.supportLibVersion}",
 
             // instrumentation test
             testRunner             : "com.android.support.test:runner:${version.testRunnerVersion}",

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -52,8 +52,7 @@ dependencies {
     implementation dependenciesList.supportAnnotation
     implementation project(':libcore')
 
-    fullImplementation dependenciesList.localBroadcastManager
-    fullImplementation dependenciesList.supportCompat
+    fullImplementation dependenciesList.supportCoreUtils
 
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockito


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-events-android/issues/359

Replace `localbroadcastmanager` and `support-compat` with `support-core-utils`. Also, downgrade support libraries to `27.1.1` to match the support library within the Maps SDK