### PR TITLE
Handle executor errors

### DIFF
--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import com.mapbox.android.core.location.LocationEngineProvider;
+import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 
 import java.util.concurrent.TimeUnit;
@@ -89,7 +90,8 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
           new SessionIdentifier(defaultInterval),
           applicationContext.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE),
           // Provide empty token as it is not available yet
-          new MapboxTelemetry(applicationContext, "", LOCATION_COLLECTOR_USER_AGENT));
+          new MapboxTelemetry(applicationContext, "",
+            String.format("%s/%s", LOCATION_COLLECTOR_USER_AGENT, BuildConfig.VERSION_NAME)));
       }
     }
     return locationCollectionClient;

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventsQueue.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventsQueue.java
@@ -2,11 +2,14 @@ package com.mapbox.android.telemetry;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
 class EventsQueue {
+  private static final String LOG_TAG = "EventsQueue";
   @VisibleForTesting
   static final int SIZE_LIMIT = 180;
   private final FullQueueCallback callback;
@@ -53,11 +56,15 @@ class EventsQueue {
   }
 
   private void dispatchCallback(final List<Event> events) {
-    executorService.execute(new Runnable() {
-      @Override
-      public void run() {
-        callback.onFullQueue(events);
-      }
-    });
+    try {
+      executorService.execute(new Runnable() {
+        @Override
+        public void run() {
+          callback.onFullQueue(events);
+        }
+      });
+    } catch (RejectedExecutionException rex) {
+      Log.e(LOG_TAG, rex.toString());
+    }
   }
 }


### PR DESCRIPTION
**Problem:**
Ran on crash while doing pre-release testing with maps sdk test app. `MapSnapshotter` test chocked up the executor's queue and resulted in the its crash:
```
    Process: com.mapbox.mapboxsdk.testapp, PID: 11852
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.mapbox.mapboxsdk.testapp/com.mapbox.mapboxsdk.testapp.activity.fragment.MultiMapActivity}: android.view.InflateException: Binary XML file line #59: Binary XML file line #59: Error inflating class fragment
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2679)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2740)
        at android.app.ActivityThread.-wrap12(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1487)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6164)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:888)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:778)
     Caused by: android.view.InflateException: Binary XML file line #59: Binary XML file line #59: Error inflating class fragment
     Caused by: android.view.InflateException: Binary XML file line #59: Error inflating class fragment
     Caused by: java.util.concurrent.RejectedExecutionException: Task com.mapbox.android.telemetry.MapboxTelemetry$4@cb9ad20 rejected from java.util.concurrent.ThreadPoolExecutor@48ea6d9[Running, pool size = 3, active threads = 3, queued tasks = 0, completed tasks = 1]
```
**Solution:**
Use more robust and universal for this use case `LinkedBlockingQueue` when events need to sit in the high priority queue and wait for the immediate delivery. Handle executor's errors.

**Test:**
Re-tested with maps sdk test app.