### PR TITLE
Fix unstable test cases in LocationCollectionClientInstrumentedTest

### DIFF
--- a/libtelemetry/src/androidTestFull/java/com/mapbox/android/telemetry/location/LocationCollectionClientInstrumentedTest.java
+++ b/libtelemetry/src/androidTestFull/java/com/mapbox/android/telemetry/location/LocationCollectionClientInstrumentedTest.java
@@ -28,11 +28,8 @@ public class LocationCollectionClientInstrumentedTest {
 
   @Before
   public void setUp() {
-    LocationCollectionClient.uninstall();
-    LocationCollectionClient newRef = LocationCollectionClient.install(InstrumentationRegistry.getTargetContext(),
+    ref = LocationCollectionClient.install(InstrumentationRegistry.getTargetContext(),
       DEFAULT_INTERVAL);
-    assertNotEquals(ref, newRef);
-    ref = newRef;
   }
 
   @After
@@ -47,7 +44,7 @@ public class LocationCollectionClientInstrumentedTest {
   }
 
   @Test
-  public void verifySharedPreference() throws InterruptedException {
+  public void verifySharedPreferences() throws InterruptedException {
     SharedPreferences sharedPreferences =
       InstrumentationRegistry.getTargetContext().getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
     assertFalse(sharedPreferences.getBoolean(LOCATION_COLLECTOR_ENABLED, true));

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
@@ -44,8 +44,8 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
   private final AtomicReference<SessionIdentifier> sessionIdentifier = new AtomicReference<>();
   private final HandlerThread settingsChangeHandlerThread;
   private final MapboxTelemetry telemetry;
+  private final SharedPreferences sharedPreferences;
   private Handler settingsChangeHandler;
-  private SharedPreferences sharedPreferences;
 
   @VisibleForTesting
   LocationCollectionClient(@NonNull LocationEngineController collectionController,
@@ -64,6 +64,7 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
         handleSettingsChangeMessage(msg);
       }
     };
+    this.sharedPreferences = sharedPreferences;
     initializeSharedPreferences(sharedPreferences);
   }
 
@@ -238,7 +239,6 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
     // We ought to reset collector state at startup,
     // this wouldn't be required in future after we migrate
     // to automatic lifecycle management.
-    this.sharedPreferences = sharedPreferences;
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putBoolean(LOCATION_COLLECTOR_ENABLED, isEnabled.get());
     editor.putLong(SESSION_ROTATION_INTERVAL_MILLIS, sessionIdentifier.get().getInterval());

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
@@ -45,6 +45,7 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
   private final HandlerThread settingsChangeHandlerThread;
   private final MapboxTelemetry telemetry;
   private Handler settingsChangeHandler;
+  private SharedPreferences sharedPreferences;
 
   @VisibleForTesting
   LocationCollectionClient(@NonNull LocationEngineController collectionController,
@@ -108,6 +109,7 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
       if (locationCollectionClient != null) {
         locationCollectionClient.locationEngineController.onDestroy();
         locationCollectionClient.settingsChangeHandlerThread.quit();
+        locationCollectionClient.sharedPreferences.unregisterOnSharedPreferenceChangeListener(locationCollectionClient);
         locationCollectionClient = null;
         uninstalled = true;
       }
@@ -236,6 +238,7 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
     // We ought to reset collector state at startup,
     // this wouldn't be required in future after we migrate
     // to automatic lifecycle management.
+    this.sharedPreferences = sharedPreferences;
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putBoolean(LOCATION_COLLECTOR_ENABLED, isEnabled.get());
     editor.putLong(SESSION_ROTATION_INTERVAL_MILLIS, sessionIdentifier.get().getInterval());


### PR DESCRIPTION
Some test cases in `LocationCollectionClientInstrumentedTest` is unstable, use `CountDownLatch` to instead of `sleep`.
In `unInstall` method of `LocationCollectionClientInstrumentedTest`, we don't unregister listener, so it will not release current object. Call `unregisterOnSharedPreferenceChangeListener` to fix it.