### PR TITLE
Call uninstall in setup method of LocationCollectionClientInstrumentedTest

### DIFF
--- a/libtelemetry/src/androidTestFull/java/com/mapbox/android/telemetry/location/LocationCollectionClientInstrumentedTest.java
+++ b/libtelemetry/src/androidTestFull/java/com/mapbox/android/telemetry/location/LocationCollectionClientInstrumentedTest.java
@@ -6,7 +6,6 @@ import android.support.test.InstrumentationRegistry;
 
 import com.mapbox.android.telemetry.MapboxTelemetry;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,13 +27,9 @@ public class LocationCollectionClientInstrumentedTest {
 
   @Before
   public void setUp() {
+    LocationCollectionClient.uninstall();
     ref = LocationCollectionClient.install(InstrumentationRegistry.getTargetContext(),
       DEFAULT_INTERVAL);
-  }
-
-  @After
-  public void tearDown() {
-    LocationCollectionClient.uninstall();
   }
 
   @Test


### PR DESCRIPTION
Since we will install LocationCollectionClient in the content provider as long as the target app is started, it will install and create  a LocationCollectionClient instance with default parameter. In this test,  the `install ` function in `setup` method will not works for the first test case.
In order to eliminate the influence on test cases, we should call `uninstall` in `setup` instead of `tearDown`.