### PR TITLE
Fix crash file counting bug

### DIFF
--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
@@ -51,18 +51,35 @@ public class MapboxUncaughtExceptionHanlderInstrumentationTest {
 
   @Test
   public void testReportCap() throws IOException {
-    for (int i = 0; i < 10; i++) {
-      File file = FileUtils.getFile(context,
-        String.format(CRASH_FILENAME_FORMAT, TELEM_MAPBOX_PACKAGE, String.format("crash%d", i)));
-      FileUtils.writeToFile(file, String.format(crashEvent, UUID.randomUUID().toString()));
-    }
-
+    writeToDisk(10);
     exceptionHanlder.setExceptionChainDepth(1);
     exceptionHanlder.uncaughtException(Thread.currentThread(), createMapboxThrowable());
 
     File[] files = directory.listFiles();
     assertNotNull(files);
     assertEquals(2, files.length);
+  }
+
+  @Test
+  public void ensureDirectoryWritableHasNoEffect() throws IOException {
+    writeToDisk(3);
+    MapboxUncaughtExceptionHanlder.ensureDirectoryWritable(context, TELEM_MAPBOX_PACKAGE);
+    assertEquals(3, directory.listFiles().length);
+  }
+
+  @Test
+  public void ensureDirectoryWritableCleansUp() throws IOException {
+    writeToDisk(10);
+    MapboxUncaughtExceptionHanlder.ensureDirectoryWritable(context, TELEM_MAPBOX_PACKAGE);
+    assertEquals(1, directory.listFiles().length);
+  }
+
+  private void writeToDisk(int numFiles) throws IOException {
+    for (int i = 0; i < numFiles; i++) {
+      File file = FileUtils.getFile(context,
+        String.format(CRASH_FILENAME_FORMAT, TELEM_MAPBOX_PACKAGE, String.format("crash%d", i)));
+      FileUtils.writeToFile(file, String.format(crashEvent, UUID.randomUUID().toString()));
+    }
   }
 
   private static Throwable createMapboxThrowable() {

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
@@ -178,16 +178,17 @@ public class MapboxUncaughtExceptionHanlder implements Thread.UncaughtExceptionH
     return level >= exceptionChainDepth;
   }
 
-  private static void ensureDirectoryWritable(@NonNull Context context, @NonNull String dirPath) {
+  @VisibleForTesting
+  static void ensureDirectoryWritable(@NonNull Context context, @NonNull String dirPath) {
     File directory = FileUtils.getFile(context, dirPath);
     if (!directory.exists()) {
       directory.mkdir();
     }
 
     // Cleanup directory if we've reached our max limit
-    if (directory.length() >= DEFAULT_MAX_REPORTS) {
-      FileUtils.deleteFirst(FileUtils.listAllFiles(directory),
-        new FileUtils.LastModifiedComparator(), DEFAULT_MAX_REPORTS - 1);
+    File [] allFiles = FileUtils.listAllFiles(directory);
+    if (allFiles.length >= DEFAULT_MAX_REPORTS) {
+      FileUtils.deleteFirst(allFiles, new FileUtils.LastModifiedComparator(), DEFAULT_MAX_REPORTS - 1);
     }
   }
 


### PR DESCRIPTION
This fixes handling of cleanup logic when we reach max allowed reports in the root directory. 
Fix misused `File#length` api, with listing all files in the root directory and counting size of its array.
Tested with instrumentation tests and manually with maps sdk test app.