### PR TITLE
Improved error handling

### DIFF
--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportBuilderInstrumentedTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportBuilderInstrumentedTest.java
@@ -78,7 +78,7 @@ public class CrashReportBuilderInstrumentedTest {
   public void checkStackTraceHash() {
     List<Throwable> causalChain = exceptionHanlder.getCausalChain(createMapboxThrowable());
     String hash = CrashReportBuilder.getStackTraceHash(causalChain);
-    assertEquals("67850f0c", hash);
+    assertEquals("34cbd8fe", hash);
   }
 
   @Test

--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
@@ -51,18 +51,35 @@ public class MapboxUncaughtExceptionHanlderInstrumentationTest {
 
   @Test
   public void testReportCap() throws IOException {
-    for (int i = 0; i < 10; i++) {
-      File file = FileUtils.getFile(context,
-        String.format(CRASH_FILENAME_FORMAT, TELEM_MAPBOX_PACKAGE, String.format("crash%d", i)));
-      FileUtils.writeToFile(file, String.format(crashEvent, UUID.randomUUID().toString()));
-    }
-
+    writeToDisk(10);
     exceptionHanlder.setExceptionChainDepth(1);
     exceptionHanlder.uncaughtException(Thread.currentThread(), createMapboxThrowable());
 
     File[] files = directory.listFiles();
     assertNotNull(files);
     assertEquals(2, files.length);
+  }
+
+  @Test
+  public void ensureDirectoryWritableHasNoEffect() throws IOException {
+    writeToDisk(3);
+    MapboxUncaughtExceptionHanlder.ensureDirectoryWritable(context, TELEM_MAPBOX_PACKAGE);
+    assertEquals(3, directory.listFiles().length);
+  }
+
+  @Test
+  public void ensureDirectoryWritableCleansUp() throws IOException {
+    writeToDisk(10);
+    MapboxUncaughtExceptionHanlder.ensureDirectoryWritable(context, TELEM_MAPBOX_PACKAGE);
+    assertEquals(1, directory.listFiles().length);
+  }
+
+  private void writeToDisk(int numFiles) throws IOException {
+    for (int i = 0; i < numFiles; i++) {
+      File file = FileUtils.getFile(context,
+        String.format(CRASH_FILENAME_FORMAT, TELEM_MAPBOX_PACKAGE, String.format("crash%d", i)));
+      FileUtils.writeToFile(file, String.format(crashEvent, UUID.randomUUID().toString()));
+    }
   }
 
   private static Throwable createMapboxThrowable() {

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
@@ -178,16 +178,17 @@ public class MapboxUncaughtExceptionHanlder implements Thread.UncaughtExceptionH
     return level >= exceptionChainDepth;
   }
 
-  private static void ensureDirectoryWritable(@NonNull Context context, @NonNull String dirPath) {
+  @VisibleForTesting
+  static void ensureDirectoryWritable(@NonNull Context context, @NonNull String dirPath) {
     File directory = FileUtils.getFile(context, dirPath);
     if (!directory.exists()) {
       directory.mkdir();
     }
 
     // Cleanup directory if we've reached our max limit
-    if (directory.length() >= DEFAULT_MAX_REPORTS) {
-      FileUtils.deleteFirst(FileUtils.listAllFiles(directory),
-        new FileUtils.LastModifiedComparator(), DEFAULT_MAX_REPORTS - 1);
+    File [] allFiles = FileUtils.listAllFiles(directory);
+    if (allFiles.length >= DEFAULT_MAX_REPORTS) {
+      FileUtils.deleteFirst(allFiles, new FileUtils.LastModifiedComparator(), DEFAULT_MAX_REPORTS - 1);
     }
   }
 

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlder.java
@@ -31,7 +31,7 @@ public class MapboxUncaughtExceptionHanlder implements Thread.UncaughtExceptionH
 
   private static final String TAG = "MbUncaughtExcHandler";
   private static final String CRASH_FILENAME_FORMAT = "%s/%s.crash";
-  private static final int DEFAULT_EXCEPTION_CHAIN_DEPTH = 3;
+  private static final int DEFAULT_EXCEPTION_CHAIN_DEPTH = 2;
   private static final int DEFAULT_MAX_REPORTS = 10;
 
   private final Thread.UncaughtExceptionHandler defaultExceptionHandler;

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/AlarmReceiver.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/AlarmReceiver.java
@@ -4,10 +4,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import static com.mapbox.android.telemetry.SchedulerFlusherFactory.SCHEDULER_FLUSHER_INTENT;
 
 class AlarmReceiver extends BroadcastReceiver {
+  private static final String TAG = "AlarmReceiver";
+
   private final SchedulerCallback callback;
 
   AlarmReceiver(@NonNull SchedulerCallback callback) {
@@ -16,8 +19,13 @@ class AlarmReceiver extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    if (SCHEDULER_FLUSHER_INTENT.equals(intent.getAction())) {
-      callback.onPeriodRaised();
+    try {
+      if (SCHEDULER_FLUSHER_INTENT.equals(intent.getAction())) {
+        callback.onPeriodRaised();
+      }
+    } catch (Throwable throwable) {
+      // TODO: log silent crash
+      Log.e(TAG, throwable.toString());
     }
   }
 

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -129,10 +129,15 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
     executeRunnable(new Runnable() {
       @Override
       public void run() {
-        SharedPreferences sharedPreferences = TelemetryUtils.obtainSharedPreferences(applicationContext);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putLong(SESSION_ROTATION_INTERVAL_MILLIS, TimeUnit.HOURS.toMillis(intervalHours));
-        editor.apply();
+        try {
+          SharedPreferences sharedPreferences = TelemetryUtils.obtainSharedPreferences(applicationContext);
+          SharedPreferences.Editor editor = sharedPreferences.edit();
+          editor.putLong(SESSION_ROTATION_INTERVAL_MILLIS, TimeUnit.HOURS.toMillis(intervalHours));
+          editor.apply();
+        } catch (Throwable throwable) {
+          // TODO: log silent crash
+          Log.e(LOG_TAG, throwable.toString());
+        }
       }
     });
     return true;
@@ -270,7 +275,12 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
     executeRunnable(new Runnable() {
       @Override
       public void run() {
-        sendEventsIfPossible(currentEvents);
+        try {
+          sendEventsIfPossible(currentEvents);
+        } catch (Throwable throwable) {
+          // TODO: log silent crash
+          Log.e(LOG_TAG, throwable.toString());
+        }
       }
     });
   }
@@ -330,7 +340,12 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
         executeRunnable(new Runnable() {
           @Override
           public void run() {
-            sendEventsIfPossible(events);
+            try {
+              sendEventsIfPossible(events);
+            } catch (Throwable throwable) {
+              // TODO: log silent crash
+              Log.e(LOG_TAG, throwable.toString());
+            }
           }
         });
         isEventSent = true;
@@ -380,10 +395,15 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
     executeRunnable(new Runnable() {
       @Override
       public void run() {
-        SharedPreferences sharedPreferences = TelemetryUtils.obtainSharedPreferences(applicationContext);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putBoolean(LOCATION_COLLECTOR_ENABLED, enable);
-        editor.apply();
+        try {
+          SharedPreferences sharedPreferences = TelemetryUtils.obtainSharedPreferences(applicationContext);
+          SharedPreferences.Editor editor = sharedPreferences.edit();
+          editor.putBoolean(LOCATION_COLLECTOR_ENABLED, enable);
+          editor.apply();
+        } catch (Throwable throwable) {
+          // TODO: log silent crash
+          Log.e(LOG_TAG, throwable.toString());
+        }
       }
     });
   }

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/crash/CrashReporterClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/crash/CrashReporterClient.java
@@ -9,6 +9,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.mapbox.android.core.FileUtils;
+import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.CrashEvent;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 import com.mapbox.android.telemetry.TelemetryListener;
@@ -51,7 +52,8 @@ final class CrashReporterClient {
     SharedPreferences sharedPreferences =
       context.getSharedPreferences(MAPBOX_CRASH_REPORTER_PREFERENCES, Context.MODE_PRIVATE);
     return new CrashReporterClient(sharedPreferences,
-      new MapboxTelemetry(context, "", CRASH_REPORTER_CLIENT_USER_AGENT), new File[0]);
+      new MapboxTelemetry(context, "",
+        String.format("%s/%s", CRASH_REPORTER_CLIENT_USER_AGENT, BuildConfig.VERSION_NAME)), new File[0]);
   }
 
   CrashReporterClient loadFrom(@NonNull File rootDir) {

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
@@ -61,7 +61,12 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
     this.settingsChangeHandler = new Handler(handlerThread.getLooper()) {
       @Override
       public void handleMessage(Message msg) {
-        handleSettingsChangeMessage(msg);
+        try {
+          handleSettingsChangeMessage(msg);
+        } catch (Throwable throwable) {
+          // TODO: log silent crash
+          Log.e(TAG, throwable.toString());
+        }
       }
     };
     this.sharedPreferences = sharedPreferences;

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import android.util.Log;
 import com.mapbox.android.core.crashreporter.MapboxUncaughtExceptionHanlder;
 import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.crash.TokenChangeBroadcastReceiver;
@@ -20,20 +21,26 @@ import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_TELEM
 import static com.mapbox.android.telemetry.location.LocationCollectionClient.DEFAULT_SESSION_ROTATION_INTERVAL_HOURS;
 
 public class MapboxTelemetryInitProvider extends ContentProvider {
+  private static final String TAG = "MbxTelemInitProvider";
   private static final String EMPTY_APPLICATION_ID_PROVIDER_AUTHORITY =
     "com.mapbox.android.telemetry.provider.mapboxtelemetryinitprovider";
 
   @Override
   public boolean onCreate() {
-    if (!BuildConfig.DEBUG) {
-      // Register broadcast receiver to get notification
-      // when valid token becomes available
-      TokenChangeBroadcastReceiver.register(getContext());
+    try {
+      if (!BuildConfig.DEBUG) {
+        // Register broadcast receiver to get notification
+        // when valid token becomes available
+        TokenChangeBroadcastReceiver.register(getContext());
 
-      // Install crash reporter for telemetry packages only!
-      MapboxUncaughtExceptionHanlder.install(getContext(), MAPBOX_TELEMETRY_PACKAGE, BuildConfig.VERSION_NAME);
+        // Install crash reporter for telemetry packages only!
+        MapboxUncaughtExceptionHanlder.install(getContext(), MAPBOX_TELEMETRY_PACKAGE, BuildConfig.VERSION_NAME);
+      }
+      LocationCollectionClient.install(getContext(), TimeUnit.HOURS.toMillis(DEFAULT_SESSION_ROTATION_INTERVAL_HOURS));
+    } catch (Throwable throwable) {
+      // TODO: log silent crash
+      Log.e(TAG, throwable.toString());
     }
-    LocationCollectionClient.install(getContext(), TimeUnit.HOURS.toMillis(DEFAULT_SESSION_ROTATION_INTERVAL_HOURS));
     return false;
   }
 

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventsQueue.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/EventsQueue.java
@@ -60,7 +60,12 @@ class EventsQueue {
       executorService.execute(new Runnable() {
         @Override
         public void run() {
-          callback.onFullQueue(events);
+          try {
+            callback.onFullQueue(events);
+          } catch (Throwable throwable) {
+            // TODO: log silent crash
+            Log.e(LOG_TAG, throwable.toString());
+          }
         }
       });
     } catch (RejectedExecutionException rex) {


### PR DESCRIPTION
This PR implements improved top level error handling per every thread that telemetry library manages internally. Solution is to catch all top level exceptions and log them as silent crashes (in future when silent crashes are added to the exception handler). 
End user should not be impacted by top level exceptions that telemetry has full control of. Tested this change with maps sdk test app.

