### PR TITLE
Fix crash due to buggy firmware

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -27,7 +27,7 @@ import okio.Buffer;
 import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES;
 
 public class TelemetryUtils {
-  private final static String TAG = "TelemetryUtils";
+  private static final String TAG = "TelemetryUtils";
   static final String MAPBOX_SHARED_PREFERENCE_KEY_VENDOR_ID = "mapboxVendorId";
   private static final String KEY_META_DATA_WAKE_UP = "com.mapbox.AdjustWakeUp";
   private static final String DATE_AND_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -24,10 +24,10 @@ import java.util.UUID;
 import android.util.Log;
 import okio.Buffer;
 
-import static android.content.ContentValues.TAG;
 import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES;
 
 public class TelemetryUtils {
+  private final static String TAG = "TelemetryUtils";
   static final String MAPBOX_SHARED_PREFERENCE_KEY_VENDOR_ID = "mapboxVendorId";
   private static final String KEY_META_DATA_WAKE_UP = "com.mapbox.AdjustWakeUp";
   private static final String DATE_AND_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";


### PR DESCRIPTION
Fixing crash due to `context#registerReceiver` on the device with buggy firmware. The crash report was received from `msm8996` device. 