### PR TITLE
Revert okhttp to version 3.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,11 +18,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     flavorDimensions "version"
     productFlavors {
         full {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 
     pluginVersion = [
             checkstyle     : '8.4',
-            gradle         : '3.3.0',
+            gradle         : '3.4.1',
             dependencyGraph: '0.5.0'
     ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
             constraintLayout    : '1.0.2',
             mockito             : '2.11.0',
             testRunnerVersion   : '1.0.1',
-            okhttp3             : '3.14.1',
+            okhttp3             : '3.12.0',
             gson                : '2.8.5',
             espressoVersion     : '3.0.1',
             archLifecycleVersion: "1.1.0",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 18 15:07:23 CET 2019
+#Thu Jun 06 12:04:38 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
     }
 
     flavorDimensions "version"


### PR DESCRIPTION
A month ago we upgraded to `okhttp 3.14.0` based on the request from the maps team: https://github.com/mapbox/mapbox-events-android/issues/375, unfortunately this version of `okhhtp` requires min `Android 5.0` and will result in crash on lower versions of the OS.