### PR TITLE
Add public api to change baseUrl for telemetry

### DIFF
--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
@@ -475,5 +476,17 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
         }
       };
     }
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public void setBaseUrl(String eventsHost) {
+    if (isValidUrl(eventsHost)) {
+      telemetryClient.setBaseUrl(eventsHost);
+    }
+  }
+
+  private static boolean isValidUrl(String eventsHost) {
+    Pattern urlPattern = Pattern.compile("^[a-z0-9]+([\\-.][a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?$");
+    return eventsHost != null && !eventsHost.isEmpty() && urlPattern.matcher(eventsHost).matches();
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetryConstants.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/MapboxTelemetryConstants.java
@@ -32,4 +32,22 @@ public final class MapboxTelemetryConstants {
    */
   public static final String MAPBOX_TELEMETRY_PACKAGE = "com.mapbox.android.telemetry";
 
+
+  /**
+   * Default telemetry host for STAGING Environment
+   */
+  @SuppressWarnings("WeakerAccess")
+  public static final String DEFAULT_STAGING_EVENTS_HOST = "api-events-staging.tilestream.net";
+
+  /**
+   * Default telemetry host for COM Environment
+   */
+  @SuppressWarnings("WeakerAccess")
+  public static final String DEFAULT_COM_EVENTS_HOST = "events.mapbox.com";
+
+  /**
+   * Default telemetry host for CHINA Environment
+   */
+  @SuppressWarnings("WeakerAccess")
+  public static final String DEFAULT_CHINA_EVENTS_HOST = "events.mapbox.cn";
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClient.java
@@ -170,4 +170,9 @@ class TelemetryClient {
 
     return builder.build();
   }
+
+  synchronized void setBaseUrl(String eventsHost) {
+    HttpUrl baseUrl = TelemetryClientSettings.configureUrlHostname(eventsHost);
+    setting = setting.toBuilder().baseUrl(baseUrl).build();
+  }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClientSettings.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClientSettings.java
@@ -13,15 +13,16 @@ import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
+import static com.mapbox.android.telemetry.MapboxTelemetryConstants.DEFAULT_CHINA_EVENTS_HOST;
+import static com.mapbox.android.telemetry.MapboxTelemetryConstants.DEFAULT_COM_EVENTS_HOST;
+import static com.mapbox.android.telemetry.MapboxTelemetryConstants.DEFAULT_STAGING_EVENTS_HOST;
+
 class TelemetryClientSettings {
-  private static final String STAGING_EVENTS_HOST = "api-events-staging.tilestream.net";
-  private static final String COM_EVENTS_HOST = "events.mapbox.com";
-  private static final String CHINA_EVENTS_HOST = "events.mapbox.cn";
   private static final Map<Environment, String> HOSTS = new HashMap<Environment, String>() {
     {
-      put(Environment.STAGING, STAGING_EVENTS_HOST);
-      put(Environment.COM, COM_EVENTS_HOST);
-      put(Environment.CHINA, CHINA_EVENTS_HOST);
+      put(Environment.STAGING, DEFAULT_STAGING_EVENTS_HOST);
+      put(Environment.COM, DEFAULT_COM_EVENTS_HOST);
+      put(Environment.CHINA, DEFAULT_CHINA_EVENTS_HOST);
     }
   };
   private static final String HTTPS_SCHEME = "https";

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientTest.java
@@ -257,6 +257,20 @@ public class TelemetryClientTest extends MockWebServerTest {
       .debug(eq("TelemetryClient"), contains(" with 1 event(s) (user agent: anyUserAgent) with payload:"));
   }
 
+  @Test
+  public void checksSetBaseUrl() throws Exception {
+    TelemetryClientSettings clientSettings = provideDefaultTelemetryClientSettings(getMockedContext());
+    Logger mockedLogger = mock(Logger.class);
+    TelemetryClient telemetryClient = new TelemetryClient("", "", clientSettings,
+            mockedLogger, mock(CertificateBlacklist.class));
+
+    String newUrl = "new-custom-url.com";
+    telemetryClient.setBaseUrl(newUrl);
+
+    assertEquals("https://" + newUrl + "/", telemetryClient.obtainSetting().getBaseUrl().toString());
+  }
+
+
   private Callback provideACallback(final CountDownLatch latch, final AtomicReference<String> bodyRef,
                                     final AtomicBoolean failureRef) {
     Callback aCallback = new Callback() {

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -9,6 +9,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,9 +18,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import okhttp3.Callback;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
+import static com.mapbox.android.telemetry.MapboxTelemetryConstants.DEFAULT_STAGING_EVENTS_HOST;
 import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -399,6 +400,70 @@ public class MapboxTelemetryTest {
     mapboxTelemetry.disable();
     // Expect to flush and disable location
     verify(mockedExecutor, times(2)).execute(any(Runnable.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithValidHost() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl(DEFAULT_STAGING_EVENTS_HOST);
+    verify(mockedTelemetryClient, times(1)).setBaseUrl(eq(DEFAULT_STAGING_EVENTS_HOST));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithNullHost() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl(null);
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithEmptyHost() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithInvalidHostOne() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("h@st.com");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithInvalidHostTwo() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("new host.com");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithInvalidHostThree() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("host..com");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithInvalidHostFour() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("host.c");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
+  }
+
+  @Test
+  public void checksSetBaseUrlWithInvalidHostFive() throws Exception {
+    TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedTelemetryClient);
+    theMapboxTelemetry.setBaseUrl("host.com.");
+    verify(mockedTelemetryClient, never()).setBaseUrl(any(String.class));
   }
 
   private MapboxTelemetry obtainMapboxTelemetry() {


### PR DESCRIPTION
Problem
Vision team need to change telemetry url at runtime depending on a current country.

Solution
Was decided to add a public API to `mapbox-events-android` lib change telemetry url dynamically.

Test
Unit tests were added to check if a new url is valid and a telemetry client receives setting with a new base url.

closes [1336](https://app.zenhub.com/workspaces/vision-sdk-5ca52e6c027e3e7234ac7512/issues/mapbox/mapbox-vision/1336)