### PR TITLE
Remove all location permissions from sdk manifest

### DIFF
--- a/libcore/src/main/AndroidManifest.xml
+++ b/libcore/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.mapbox.android.core">
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/liblocation/src/main/AndroidManifest.xml
+++ b/liblocation/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.mapbox.android.location">
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngineImpl.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/AndroidLocationEngineImpl.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.core.location;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Criteria;
@@ -52,6 +53,7 @@ class AndroidLocationEngineImpl implements LocationEngineImpl<LocationListener> 
     callback.onFailure(new Exception("Last location unavailable"));
   }
 
+  @SuppressLint("MissingPermission")
   Location getLastLocationFor(String provider) throws SecurityException {
     Location location = null;
     try {
@@ -62,6 +64,7 @@ class AndroidLocationEngineImpl implements LocationEngineImpl<LocationListener> 
     return location;
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull LocationListener listener,
@@ -72,6 +75,7 @@ class AndroidLocationEngineImpl implements LocationEngineImpl<LocationListener> 
       listener, looper);
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull PendingIntent pendingIntent) throws SecurityException {
@@ -81,6 +85,7 @@ class AndroidLocationEngineImpl implements LocationEngineImpl<LocationListener> 
       request.getDisplacemnt(), pendingIntent);
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void removeLocationUpdates(@NonNull LocationListener listener) {
     if (listener != null) {

--- a/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngineImpl.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/GoogleLocationEngineImpl.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.core.location;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
@@ -40,6 +41,7 @@ class GoogleLocationEngineImpl implements LocationEngineImpl<LocationCallback> {
     return new GoogleLocationEngineCallbackTransport(callback);
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void getLastLocation(@NonNull LocationEngineCallback<LocationEngineResult> callback)
     throws SecurityException {
@@ -48,6 +50,7 @@ class GoogleLocationEngineImpl implements LocationEngineImpl<LocationCallback> {
     fusedLocationProviderClient.getLastLocation().addOnSuccessListener(transport).addOnFailureListener(transport);
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull LocationCallback listener,
@@ -55,6 +58,7 @@ class GoogleLocationEngineImpl implements LocationEngineImpl<LocationCallback> {
     fusedLocationProviderClient.requestLocationUpdates(toGMSLocationRequest(request), listener, looper);
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull PendingIntent pendingIntent) throws SecurityException {

--- a/liblocation/src/main/java/com/mapbox/android/core/location/MapboxFusedLocationEngineImpl.java
+++ b/liblocation/src/main/java/com/mapbox/android/core/location/MapboxFusedLocationEngineImpl.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.core.location;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
@@ -41,6 +42,7 @@ class MapboxFusedLocationEngineImpl extends AndroidLocationEngineImpl {
     }
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull LocationListener listener,
@@ -59,6 +61,7 @@ class MapboxFusedLocationEngineImpl extends AndroidLocationEngineImpl {
     }
   }
 
+  @SuppressLint("MissingPermission")
   @Override
   public void requestLocationUpdates(@NonNull LocationEngineRequest request,
                                      @NonNull PendingIntent pendingIntent) throws SecurityException {

--- a/libtelemetry/src/full/AndroidManifest.xml
+++ b/libtelemetry/src/full/AndroidManifest.xml
@@ -5,7 +5,6 @@
 
     <!--Required for CrashReporterJobIntentService on API levels below 25-->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationEngineControllerImpl.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationEngineControllerImpl.java
@@ -1,6 +1,7 @@
 package com.mapbox.android.telemetry.location;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -63,6 +64,7 @@ class LocationEngineControllerImpl implements LocationEngineController {
     }
   }
 
+  @SuppressLint("MissingPermission")
   private void requestLocationUpdates() {
     if (!checkPermissions()) {
       Log.w(TAG, "Location permissions are not granted");

--- a/libtelemetry/src/main/AndroidManifest.xml
+++ b/libtelemetry/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapbox.android.telemetry">
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>


### PR DESCRIPTION
Problem
For apps targeting <= Android 9 but running on Android 10, the system automatically adds ACCESS_BACKGROUND_LOCATION when updating to Android 10 if either of ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION is declared in the manifest.

Solution
Removing all location permissions from SDK to prevent ACCESS_BACKGROUND_LOCATION being added to app's manifest as a result of inheriting location permissions from SDK.

Removing all location permissions from SDK to prevent apps from inheriting location permissions from SDK.

Test
Build [Navigation](https://github.com/mapbox/mapbox-navigation-android) and [Maps](https://github.com/mapbox/mapbox-gl-native-android) successfully.