### PR TITLE
Apply android-sdk-versions-plugin to Telemetry and Core modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath pluginDependencies.gradle
-        classpath pluginDependencies.mapboxSDKVersions
+        classpath pluginDependencies.mapboxSdkVersions
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 
     dependencies {
         classpath pluginDependencies.gradle
+        classpath pluginDependencies.mapboxSDKVersions
     }
 }
 
@@ -42,6 +43,7 @@ subprojects { subproject ->
     if (RELEASE_MODULES.contains(subproject.name)) {
         subproject.afterEvaluate {
             subproject.apply from: "javadoc.gradle"
+            subproject.apply plugin: 'com.mapbox.android.sdk.versions'
         }
         subproject.apply from: "${rootDir}/gradle/mvn-push-android.gradle"
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,9 +22,10 @@ ext {
     ]
 
     pluginVersion = [
-            checkstyle     : '8.4',
-            gradle         : '3.4.1',
-            dependencyGraph: '0.5.0'
+            checkstyle       : '8.4',
+            gradle           : '3.4.1',
+            dependencyGraph  : '0.5.0',
+            mapboxSDKVersions: '0.1.3'
     ]
 
     dependenciesList = [
@@ -70,8 +71,9 @@ ext {
     ]
 
     pluginDependencies = [
-            gradle         : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-            checkstyle     : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-            dependencyGraph: "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}"
+            gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+            checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+            dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+            mapboxSDKVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSDKVersions}"
     ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
             checkstyle       : '8.4',
             gradle           : '3.4.1',
             dependencyGraph  : '0.5.0',
-            mapboxSDKVersions: '0.1.3'
+            mapboxSdkVersions: '0.1.3'
     ]
 
     dependenciesList = [
@@ -74,6 +74,6 @@ ext {
             gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
             checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
             dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-            mapboxSDKVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSDKVersions}"
+            mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}"
     ]
 }

--- a/libcore/src/androidTest/java/com/mapbox/android/core/CoreSDKVersionTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/CoreSDKVersionTest.java
@@ -1,0 +1,44 @@
+package com.mapbox.android.core;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.support.test.InstrumentationRegistry;
+import android.util.Log;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.junit.Assert.fail;
+
+public class CoreSDKVersionTest {
+
+  private static final String SECOND_LINE_FORMAT = "v%d";
+  private static final String SDK_VERSIONS_FOLDER = "sdk_versions";
+  private static final String LOG_TAG = "CoreSDKVersionTest";
+
+  @Test
+  public void testPersistedCoreSDKInfo() {
+    Context context = InstrumentationRegistry.getTargetContext();
+    AssetManager assetManager = context.getAssets();
+    InputStream is = null;
+
+    try {
+      is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + context.getPackageName()
+        .replace(".test", ""));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      Assert.assertEquals(reader.readLine().split("/")[1], BuildConfig.VERSION_NAME);
+      Assert.assertEquals(reader.readLine(), String.format(SECOND_LINE_FORMAT, BuildConfig.VERSION_CODE));
+    } catch (IOException exception) {
+      Log.e(LOG_TAG, exception.toString());
+      fail();
+    } finally {
+      FileUtils.closeQuietly(is);
+    }
+  }
+}

--- a/libcore/src/androidTest/java/com/mapbox/android/core/CoreSDKVersionTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/CoreSDKVersionTest.java
@@ -26,19 +26,19 @@ public class CoreSDKVersionTest {
   public void testPersistedCoreSDKInfo() {
     Context context = InstrumentationRegistry.getTargetContext();
     AssetManager assetManager = context.getAssets();
-    InputStream is = null;
+    InputStream inputStream = null;
 
     try {
-      is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + context.getPackageName()
-        .replace(".test", ""));
-      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      String packageName = context.getPackageName().replace(".test", "");
+      inputStream = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + packageName);
+      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
       Assert.assertEquals(reader.readLine().split("/")[1], BuildConfig.VERSION_NAME);
       Assert.assertEquals(reader.readLine(), String.format(SECOND_LINE_FORMAT, BuildConfig.VERSION_CODE));
     } catch (IOException exception) {
       Log.e(LOG_TAG, exception.toString());
-      fail();
+      fail(exception.toString());
     } finally {
-      FileUtils.closeQuietly(is);
+      FileUtils.closeQuietly(inputStream);
     }
   }
 }

--- a/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
+++ b/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
@@ -1,0 +1,2 @@
+libcore/1.4.0-SNAPSHOT
+v1

--- a/libcore/src/main/java/com/mapbox/android/core/FileUtils.java
+++ b/libcore/src/main/java/com/mapbox/android/core/FileUtils.java
@@ -2,8 +2,10 @@ package com.mapbox.android.core;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -144,5 +146,16 @@ public final class FileUtils {
       long o2LastModified = o2.lastModified();
       return o1LastModified < o2LastModified ? -1 : (o1LastModified == o2LastModified ? 0 : 1);
     }
+  }
+
+  public static void closeQuietly(@Nullable Closeable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (IOException var1) {
+        //This is ok to happen.
+      }
+    }
+
   }
 }

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetrySDKVersionTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetrySDKVersionTest.java
@@ -1,0 +1,46 @@
+package com.mapbox.android.telemetry;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.support.test.InstrumentationRegistry;
+import android.util.Log;
+
+import com.mapbox.android.core.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.junit.Assert.fail;
+
+public class TelemetrySDKVersionTest {
+
+  private static final String SECOND_LINE_FORMAT = "v%d";
+  private static final String SDK_VERSIONS_FOLDER = "sdk_versions";
+  private static final String LOG_TAG = "TelemetrySDKVersionTest";
+
+  @Test
+  public void testPersistedTelemetrySDKInfo() {
+    Context context = InstrumentationRegistry.getTargetContext();
+    AssetManager assetManager = context.getAssets();
+    InputStream is = null;
+
+    try {
+      is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + context.getPackageName()
+        .replace(".test", ""));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      Assert.assertEquals(reader.readLine().split("/")[1], BuildConfig.VERSION_NAME);
+      Assert.assertEquals(reader.readLine(), String.format(SECOND_LINE_FORMAT, BuildConfig.VERSION_CODE));
+    } catch (IOException exception) {
+      Log.e(LOG_TAG, exception.toString());
+      fail(exception.toString());
+    } finally {
+      FileUtils.closeQuietly(is);
+    }
+  }
+}

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetrySDKVersionTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TelemetrySDKVersionTest.java
@@ -28,19 +28,19 @@ public class TelemetrySDKVersionTest {
   public void testPersistedTelemetrySDKInfo() {
     Context context = InstrumentationRegistry.getTargetContext();
     AssetManager assetManager = context.getAssets();
-    InputStream is = null;
+    InputStream inputStream = null;
 
     try {
-      is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + context.getPackageName()
-        .replace(".test", ""));
-      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      String packageName = context.getPackageName().replace(".test", "");
+      inputStream = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + packageName);
+      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
       Assert.assertEquals(reader.readLine().split("/")[1], BuildConfig.VERSION_NAME);
       Assert.assertEquals(reader.readLine(), String.format(SECOND_LINE_FORMAT, BuildConfig.VERSION_CODE));
     } catch (IOException exception) {
       Log.e(LOG_TAG, exception.toString());
       fail(exception.toString());
     } finally {
-      FileUtils.closeQuietly(is);
+      FileUtils.closeQuietly(inputStream);
     }
   }
 }

--- a/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
+++ b/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
@@ -1,0 +1,2 @@
+libtelemetry/4.7.0-SNAPSHOT
+v1


### PR DESCRIPTION
This plugin https://github.com/mapbox/android-sdk-versions-plugin validates and persists the SDK version into a file in assets folder. This information further feeds into Reformed User Agent.
https://github.com/mapbox/mobile-telemetry/issues/452
https://github.com/mapbox/mobile-telemetry/issues/423