### PR TITLE
Generate Reformed User Agent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
@@ -37,7 +37,7 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
-    mapboxTelemetry = new MapboxTelemetry(this, obtainAccessToken(), LOG_TAG);
+    mapboxTelemetry = new MapboxTelemetry(this, obtainAccessToken());
     mapboxTelemetry.updateDebugLoggingEnabled(true);
     mapboxTelemetry.addTelemetryListener(new TelemetryListenerWrapper(this));
     mapboxTelemetry.push(new AppUserTurnstile("fooSdk", "1.0.0"));

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
             checkstyle       : '8.4',
             gradle           : '3.4.1',
             dependencyGraph  : '0.5.0',
-            mapboxSdkVersions: '0.1.3'
+            mapboxSdkVersions: '1.0.0'
     ]
 
     dependenciesList = [

--- a/libcore/src/androidTest/java/com/mapbox/android/core/UserAgentSDKInfoTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/UserAgentSDKInfoTest.java
@@ -1,0 +1,45 @@
+package com.mapbox.android.core;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class UserAgentSDKInfoTest {
+
+  private static final String SDK_UA_FORMAT = "%s/%s (%s; %s)";
+  private static final String SDK_UA_VERSION_CODE_FORMAT = "v%d";
+  private static final Locale LOCALE_DEFAULT = Locale.US;
+  private static final String NAME = "libcore";
+
+  @Test
+  public void testSDKInformation() {
+    Context context = InstrumentationRegistry.getContext();
+    String packageName = context.getPackageName().replace(".test", "");
+    String versionCode = String.format(LOCALE_DEFAULT, SDK_UA_VERSION_CODE_FORMAT, BuildConfig.VERSION_CODE);
+    String sdkInfo = MapboxSdkInfoForUserAgentGenerator.getInstance(context.getAssets())
+      .getMapboxSdkIdentifiersForUserAgent(context.getAssets());
+    Assert.assertEquals(String.format(Locale.US, SDK_UA_FORMAT, NAME, BuildConfig.VERSION_NAME,
+      packageName, versionCode), sdkInfo);
+  }
+
+  @Test
+  public void testUserAgentSdkInfo() {
+    Context context = InstrumentationRegistry.getContext();
+    String sdkInfo = MapboxSdkInfoForUserAgentGenerator.getInstance(context.getAssets())
+      .getSdkInfoForUserAgent();
+    String packageName = context.getPackageName().replace(".test", "");
+    String versionCode = String.format(LOCALE_DEFAULT, SDK_UA_VERSION_CODE_FORMAT, BuildConfig.VERSION_CODE);
+    Assert.assertEquals(String.format(Locale.US, SDK_UA_FORMAT, NAME, BuildConfig.VERSION_NAME,
+      packageName, versionCode), sdkInfo);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSDKInformationInUserAgentWithNullContext() {
+    MapboxSdkInfoForUserAgentGenerator.getInstance(null)
+      .getSdkInfoForUserAgent();
+  }
+}

--- a/libcore/src/main/java/com/mapbox/android/core/MapboxSdkInfoForUserAgentGenerator.java
+++ b/libcore/src/main/java/com/mapbox/android/core/MapboxSdkInfoForUserAgentGenerator.java
@@ -13,6 +13,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Locale;
 
+/**
+ * Generator that reads(from assets/sdk_versions folder) and constructs Mapbox SDK versions for user agent.
+ * Generates strings in format for each Mapbox library in the host app and concatenates them seperated by spaces.
+ * <p> User agent format for Mapbox SDK : {SDK Name}/{Version} {(packageName; versionCode)} </p>
+ */
 public class MapboxSdkInfoForUserAgentGenerator {
 
   private static MapboxSdkInfoForUserAgentGenerator userAgentGenerator;
@@ -48,10 +53,10 @@ public class MapboxSdkInfoForUserAgentGenerator {
       if (files != null) {
         for (String fileName : files) {
           if (fileName.contains(MAPBOX_IDENTIFIER)) {
-            InputStream is = null;
+            InputStream inputStream = null;
             try {
-              is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + fileName);
-              BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+              inputStream = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + fileName);
+              BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
               String nameAndVersion = reader.readLine();
               nameAndVersion = nameAndVersion != null ? nameAndVersion : EMPTY_STRING;
               StringBuilder sdkSubInfo = new StringBuilder(EMPTY_STRING);
@@ -60,12 +65,13 @@ public class MapboxSdkInfoForUserAgentGenerator {
                 sdkSubInfo.append("; ");
                 sdkSubInfo.append(subInfo);
               }
+              reader.close();
               stringBuilder.append(String.format(DEFAULT_LOCALE, USER_AGENT_SDK_VERSION_FORMAT,
                 nameAndVersion, fileName, sdkSubInfo.toString()));
             } catch (IOException exception) {
               Log.e(LOG_TAG, exception.toString());
             } finally {
-              FileUtils.closeQuietly(is);
+              FileUtils.closeQuietly(inputStream);
             }
           }
         }

--- a/libcore/src/main/java/com/mapbox/android/core/MapboxSdkInfoForUserAgentGenerator.java
+++ b/libcore/src/main/java/com/mapbox/android/core/MapboxSdkInfoForUserAgentGenerator.java
@@ -1,0 +1,82 @@
+package com.mapbox.android.core;
+
+import android.content.res.AssetManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Locale;
+
+public class MapboxSdkInfoForUserAgentGenerator {
+
+  private static MapboxSdkInfoForUserAgentGenerator userAgentGenerator;
+
+  private String sdkInfoForUserAgent;
+  private static final Object lock = new Object();
+  private static final Locale DEFAULT_LOCALE = Locale.US;
+  private static final String USER_AGENT_SDK_VERSION_FORMAT = " %s (%s%s)";
+  private static final String MAPBOX_IDENTIFIER = "mapbox";
+  private static final String EMPTY_STRING = "";
+  private static final String SDK_VERSIONS_FOLDER = "sdk_versions";
+  private static final String LOG_TAG = "MapboxUAGenerator";
+
+  private MapboxSdkInfoForUserAgentGenerator(AssetManager assetManager) {
+    this.sdkInfoForUserAgent = getMapboxSdkIdentifiersForUserAgent(assetManager);
+  }
+
+  public static MapboxSdkInfoForUserAgentGenerator getInstance(@NonNull AssetManager assetManager) {
+    if (userAgentGenerator == null) {
+      synchronized (lock) {
+        userAgentGenerator = new MapboxSdkInfoForUserAgentGenerator(assetManager);
+      }
+    }
+    return userAgentGenerator;
+  }
+
+  @VisibleForTesting
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
+  String getMapboxSdkIdentifiersForUserAgent(@NonNull AssetManager assetManager) {
+    StringBuilder stringBuilder = new StringBuilder(EMPTY_STRING);
+    try {
+      String[] files = assetManager.list(SDK_VERSIONS_FOLDER);
+      if (files != null) {
+        for (String fileName : files) {
+          if (fileName.contains(MAPBOX_IDENTIFIER)) {
+            InputStream is = null;
+            try {
+              is = assetManager.open(SDK_VERSIONS_FOLDER + File.separator + fileName);
+              BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+              String nameAndVersion = reader.readLine();
+              nameAndVersion = nameAndVersion != null ? nameAndVersion : EMPTY_STRING;
+              StringBuilder sdkSubInfo = new StringBuilder(EMPTY_STRING);
+              String subInfo;
+              while ((subInfo = reader.readLine()) != null) {
+                sdkSubInfo.append("; ");
+                sdkSubInfo.append(subInfo);
+              }
+              stringBuilder.append(String.format(DEFAULT_LOCALE, USER_AGENT_SDK_VERSION_FORMAT,
+                nameAndVersion, fileName, sdkSubInfo.toString()));
+            } catch (IOException exception) {
+              Log.e(LOG_TAG, exception.toString());
+            } finally {
+              FileUtils.closeQuietly(is);
+            }
+          }
+        }
+      }
+    } catch (IOException exception) {
+      Log.e(LOG_TAG, exception.toString());
+    }
+    return stringBuilder.toString().trim();
+  }
+
+  public String getSdkInfoForUserAgent() {
+    return sdkInfoForUserAgent;
+  }
+}

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/CertificateBlacklistInstrumentationTests.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/CertificateBlacklistInstrumentationTests.java
@@ -33,7 +33,7 @@ public class CertificateBlacklistInstrumentationTests {
     setSystemPrefs();
 
     ConfigurationClient configurationClient = new ConfigurationClient(context,
-      TelemetryUtils.createFullUserAgent("AnUserAgent", context), "anAccessToken", new OkHttpClient());
+      TelemetryUtils.createFullUserAgent(context), "anAccessToken", new OkHttpClient());
     this.certificateBlacklist = new CertificateBlacklist(context, configurationClient);
   }
 
@@ -95,7 +95,7 @@ public class CertificateBlacklistInstrumentationTests {
 
     Context context = InstrumentationRegistry.getTargetContext();
     ConfigurationClient configurationClient = new ConfigurationClient(context,
-      TelemetryUtils.createFullUserAgent("AnUserAgent", context), "anAccessToken", new OkHttpClient());
+      TelemetryUtils.createFullUserAgent(context), "anAccessToken", new OkHttpClient());
     this.certificateBlacklist = new CertificateBlacklist(context, configurationClient);
     assertTrue(certificateBlacklist.isBlacklisted("test12345"));
   }

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/ConfigurationClientInstrumentationTest.java
@@ -39,7 +39,7 @@ public class ConfigurationClientInstrumentationTest {
   public void setup() {
     Context context = InstrumentationRegistry.getTargetContext();
     this.configurationClient = new ConfigurationClient(context,
-      TelemetryUtils.createFullUserAgent("AnUserAgent", context), "anAccessToken", new OkHttpClient());
+      TelemetryUtils.createFullUserAgent(context), "anAccessToken", new OkHttpClient());
   }
 
   @Test
@@ -48,7 +48,7 @@ public class ConfigurationClientInstrumentationTest {
     OkHttpClient httpClient = mock(OkHttpClient.class);
     when(httpClient.newCall(any(Request.class))).thenReturn(mock(Call.class));
     this.configurationClient = new ConfigurationClient(context,
-      TelemetryUtils.createFullUserAgent("AnUserAgent", context), "anAccessToken", httpClient);
+      TelemetryUtils.createFullUserAgent(context), "anAccessToken", httpClient);
     configurationClient.update();
     ArgumentCaptor<Request> argument = ArgumentCaptor.forClass(Request.class);
     verify(httpClient).newCall(argument.capture());
@@ -71,7 +71,7 @@ public class ConfigurationClientInstrumentationTest {
     OkHttpClient httpClient = mock(OkHttpClient.class);
     when(httpClient.newCall((Request) any())).thenReturn(mock(Call.class));
     this.configurationClient = new ConfigurationClient(context,
-      TelemetryUtils.createFullUserAgent("AnUserAgent", InstrumentationRegistry.getTargetContext()),
+      TelemetryUtils.createFullUserAgent(InstrumentationRegistry.getTargetContext()),
       "anAccessToken", httpClient);
 
     configurationClient.update();

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/crash/CrashReporterClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/crash/CrashReporterClient.java
@@ -9,7 +9,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.mapbox.android.core.FileUtils;
-import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.CrashEvent;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 import com.mapbox.android.telemetry.TelemetryListener;
@@ -28,7 +27,6 @@ import static com.mapbox.android.core.crashreporter.MapboxUncaughtExceptionHanld
 
 final class CrashReporterClient {
   private static final String LOG_TAG = "CrashReporterClient";
-  private static final String CRASH_REPORTER_CLIENT_USER_AGENT = "mapbox-android-crash";
   private final SharedPreferences sharedPreferences;
   private final MapboxTelemetry telemetry;
   private final HashSet<String> crashHashSet = new HashSet<>();
@@ -52,8 +50,7 @@ final class CrashReporterClient {
     SharedPreferences sharedPreferences =
       context.getSharedPreferences(MAPBOX_CRASH_REPORTER_PREFERENCES, Context.MODE_PRIVATE);
     return new CrashReporterClient(sharedPreferences,
-      new MapboxTelemetry(context, "",
-        String.format("%s/%s", CRASH_REPORTER_CLIENT_USER_AGENT, BuildConfig.VERSION_NAME)), new File[0]);
+      new MapboxTelemetry(context, ""), new File[0]);
   }
 
   CrashReporterClient loadFrom(@NonNull File rootDir) {

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationCollectionClient.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import com.mapbox.android.core.location.LocationEngineProvider;
-import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 
 import java.util.concurrent.TimeUnit;
@@ -31,7 +30,6 @@ import static com.mapbox.android.telemetry.MapboxTelemetryConstants.SESSION_ROTA
  */
 public class LocationCollectionClient implements SharedPreferences.OnSharedPreferenceChangeListener {
   public static final int DEFAULT_SESSION_ROTATION_INTERVAL_HOURS = 24;
-  private static final String LOCATION_COLLECTOR_USER_AGENT = "mapbox-android-location";
   private static final String TAG = "LocationCollectionCli";
   private static final int LOCATION_COLLECTION_STATUS_UPDATED = 0;
   private static final Object lock = new Object();
@@ -97,8 +95,7 @@ public class LocationCollectionClient implements SharedPreferences.OnSharedPrefe
           new SessionIdentifier(defaultInterval),
           applicationContext.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE),
           // Provide empty token as it is not available yet
-          new MapboxTelemetry(applicationContext, "",
-            String.format("%s/%s", LOCATION_COLLECTOR_USER_AGENT, BuildConfig.VERSION_NAME)));
+          new MapboxTelemetry(applicationContext, ""));
       }
     }
     return locationCollectionClient;

--- a/libtelemetry/src/lite/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/lite/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -17,7 +17,6 @@ import okhttp3.ResponseBody;
 public class MapboxTelemetry {
   private static final String NON_NULL_APPLICATION_CONTEXT_REQUIRED = "Non-null application context required.";
   private String accessToken;
-  private String userAgent;
   private TelemetryClient telemetryClient;
   private Callback httpCallback;
   private CopyOnWriteArraySet<TelemetryListener> telemetryListeners = null;
@@ -25,6 +24,11 @@ public class MapboxTelemetry {
   private final ConfigurationClient configurationClient;
   static Context applicationContext = null;
 
+  /**
+   * @deprecated as of Release 4.7.0.
+   * Custom user agent is no longer accepted. Telemetry constructs the User Agent.
+   * Use {@link #MapboxTelemetry(Context, String)}
+   */
   @Deprecated
   public MapboxTelemetry(Context context, String accessToken, String userAgent) {
     initializeContext(context);
@@ -100,10 +104,12 @@ public class MapboxTelemetry {
     }
   }
 
+  /**
+   * @deprecated This method has no significance as of Release 4.7.0
+   * Custom user agent is not accepted any longer. Telemetry constructs the user agent.
+   */
   @Deprecated
-  public void updateUserAgent(String userAgent) {
-
-  }
+  public void updateUserAgent(String userAgent) {}
 
   public boolean updateAccessToken(String accessToken) {
     if (isAccessTokenValid(accessToken) && updateTelemetryClient(accessToken)) {

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -227,14 +227,14 @@ public class TelemetryUtils {
   }
 
   private static String getApplicationName(Context context) {
-    final PackageManager pm = context.getApplicationContext().getPackageManager();
-    ApplicationInfo ai;
+    final PackageManager packagemanager = context.getApplicationContext().getPackageManager();
+    ApplicationInfo applicationInfo;
     try {
-      ai = pm.getApplicationInfo(context.getPackageName(), 0);
+      applicationInfo = packagemanager.getApplicationInfo(context.getPackageName(), 0);
     } catch (final PackageManager.NameNotFoundException nameNotFoundException) {
-      ai = null;
+      applicationInfo = null;
     }
-    return (String) (ai != null ? pm.getApplicationLabel(ai) : "(unknown)");
+    return (String) (applicationInfo != null ? packagemanager.getApplicationLabel(applicationInfo) : "(unknown)");
   }
 
   /**

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/metrics/TelemetryMetricsClient.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/metrics/TelemetryMetricsClient.java
@@ -7,7 +7,6 @@ import android.support.annotation.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 
 public class TelemetryMetricsClient {
-  private static final String TELEMETRY_METRICS_USER_AGENT = "mapbox-android-metrics";
   private static TelemetryMetricsClient telemetryMetricsClient;
   private static final Object lock = new Object();
   private final TelemetryMetrics telemetryMetrics;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/ConfigurationClientTest.java
@@ -79,7 +79,7 @@ public class ConfigurationClientTest {
       .thenReturn(Long.valueOf(0));
     when(mockedSharedPreferences.edit()).thenReturn(mockedEditor);
 
-    this.configurationClient = new ConfigurationClient(mockedContext, TelemetryUtils.createFullUserAgent("AnUserAgent",
+    this.configurationClient = new ConfigurationClient(mockedContext, TelemetryUtils.createFullUserAgent(
       mockedContext), "anAccessToken", client);
   }
 

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -181,7 +181,7 @@ public class MapboxTelemetryTest {
     MapboxTelemetry.applicationContext = mockedContext;
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, null,
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext,
       null, mockedTelemetryClient, mockedHttpCallback);
     List<Event> mockedList = mock(List.class);
     theMapboxTelemetry.onFullQueue(mockedList);
@@ -192,11 +192,10 @@ public class MapboxTelemetryTest {
   public void checksOnFullQueueSendEventsNotCalledWhenEmptyTelemetryClient() throws Exception {
     Context mockedContext = obtainNetworkConnectedMockedContext();
     String emptyValidAccessToken = "";
-    String emptyUserAgent = "";
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, emptyValidAccessToken,
-      emptyUserAgent, mockedTelemetryClient, mockedHttpCallback);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext,
+      emptyValidAccessToken, mockedTelemetryClient, mockedHttpCallback);
     List<Event> mockedList = mock(List.class);
     theMapboxTelemetry.onFullQueue(mockedList);
     verify(mockedTelemetryClient, never()).sendEvents(eq(mockedList), eq(mockedHttpCallback), anyBoolean());
@@ -206,10 +205,9 @@ public class MapboxTelemetryTest {
   public void checksValidAccessTokenValidUserAgent() throws Exception {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken, aValidUserAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken, aValidUserAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
   }
 
@@ -217,12 +215,9 @@ public class MapboxTelemetryTest {
   public void checksNullAccessToken() throws Exception {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String invalidAccessTokenNull = null;
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, invalidAccessTokenNull,
-      aValidUserAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, invalidAccessTokenNull);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(invalidAccessTokenNull,
-      aValidUserAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(invalidAccessTokenNull);
     assertFalse(validRequiredParameters);
   }
 
@@ -230,12 +225,9 @@ public class MapboxTelemetryTest {
   public void checksUserAgentTelemetryAndroid() throws Exception {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String aValidAccessToken = "validAccessToken";
-    String theTelemetryAndroidAgent = "MapboxTelemetryAndroid/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken,
-      theTelemetryAndroidAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken,
-      theTelemetryAndroidAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
   }
 
@@ -244,24 +236,19 @@ public class MapboxTelemetryTest {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String aValidAccessToken = "validAccessToken";
     String theUnityAndroidAgent = "MapboxEventsUnityAndroid/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken,
-      theUnityAndroidAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken,
-      theUnityAndroidAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
   }
 
   @Test
   public void checksUserAgentNavigation() throws Exception {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
-    String aValidAccessToken = "validAccessToken";
-    String theNavigationAndroidAgent = "mapbox-navigation-android/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken,
-      theNavigationAndroidAgent);
+    String aValidAccessToken = "validAccessToken";;
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken,
-      theNavigationAndroidAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
   }
 
@@ -270,11 +257,9 @@ public class MapboxTelemetryTest {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String aValidAccessToken = "validAccessToken";
     String theNavigationUiAndroidAgent = "mapbox-navigation-ui-android/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken,
-      theNavigationUiAndroidAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken,
-      theNavigationUiAndroidAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
   }
 
@@ -282,25 +267,10 @@ public class MapboxTelemetryTest {
   public void checksUserAgentEvents() throws Exception {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     String aValidAccessToken = "validAccessToken";
-    String theEventsAndroidAgent = "MapboxEventsAndroid/";
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken,
-      theEventsAndroidAgent);
+    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken);
     theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken,
-      theEventsAndroidAgent);
+    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken);
     assertTrue(validRequiredParameters);
-  }
-
-  @Test
-  public void checksNullUserAgent() throws Exception {
-    Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
-    MapboxTelemetry.applicationContext = mockedContext;
-    String aValidAccessToken = "validAccessToken";
-    String aNullUserAgent = null;
-    MapboxTelemetry theMapboxTelemetry = obtainMapboxTelemetryWith(mockedContext, aValidAccessToken, aNullUserAgent);
-    theMapboxTelemetry.enable();
-    boolean validRequiredParameters = theMapboxTelemetry.checkRequiredParameters(aValidAccessToken, aNullUserAgent);
-    assertFalse(validRequiredParameters);
   }
 
   @Test
@@ -475,7 +445,6 @@ public class MapboxTelemetryTest {
   private MapboxTelemetry obtainMapboxTelemetryWith(ExecutorService mockedExecutor) {
     MapboxTelemetry.applicationContext = obtainNetworkConnectedMockedContext();
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     EventsQueue eventsQueue = new EventsQueue(new ConcurrentQueue<Event>(),
       mock(FullQueueCallback.class), mock(ExecutorService.class));
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
@@ -484,7 +453,7 @@ public class MapboxTelemetryTest {
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
     return new MapboxTelemetry(MapboxTelemetry.applicationContext,
-      aValidAccessToken, aValidUserAgent, eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher,
+      aValidAccessToken, eventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher,
       mockedClock, telemetryEnabler, mockedExecutor);
   }
 
@@ -494,13 +463,12 @@ public class MapboxTelemetryTest {
     when(mockedContext.getFilesDir()).thenReturn(mockedFile);
     MapboxTelemetry.applicationContext = mockedContext;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     Callback mockedHttpCallback = mock(Callback.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    return new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent,
+    return new MapboxTelemetry(mockedContext, aValidAccessToken,
       mockedEventsQueue, telemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
   }
@@ -509,14 +477,13 @@ public class MapboxTelemetryTest {
                                                     Callback httpCallback) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
     ExecutorService mockedExecutor = mock(ExecutorService.class);
     setupDirectExecutor(mockedExecutor);
-    return new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
+    return new MapboxTelemetry(context, aValidAccessToken,
       mockedEventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mockedExecutor);
   }
@@ -525,7 +492,6 @@ public class MapboxTelemetryTest {
                                                     TelemetryEnabler.State state) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
@@ -534,21 +500,20 @@ public class MapboxTelemetryTest {
     telemetryEnabler.updatePreferences(state);
     ExecutorService mockedExecutor = mock(ExecutorService.class);
     setupDirectExecutor(mockedExecutor);
-    return new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
-      eventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
+    return new MapboxTelemetry(context, aValidAccessToken, eventsQueue,
+      mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mockedExecutor);
   }
 
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context, EventsQueue eventsQueue) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
+    MapboxTelemetry mapboxTelemetry = new MapboxTelemetry(context, aValidAccessToken,
       eventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
     return mapboxTelemetry;
@@ -557,18 +522,17 @@ public class MapboxTelemetryTest {
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context, SchedulerFlusher schedulerFlusher) {
     MapboxTelemetry.applicationContext = context;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    return new MapboxTelemetry(context, aValidAccessToken, aValidUserAgent,
+    return new MapboxTelemetry(context, aValidAccessToken,
       mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, schedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
   }
 
-  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, String accessToken, String userAgent) {
+  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, String accessToken) {
     MapboxTelemetry.applicationContext = context;
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
@@ -576,20 +540,21 @@ public class MapboxTelemetryTest {
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    return new MapboxTelemetry(context, accessToken, userAgent,
+    return new MapboxTelemetry(context, accessToken,
       mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
   }
 
-  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, String accessToken, String userAgent,
+  private MapboxTelemetry obtainMapboxTelemetryWith(Context context, String accessToken,
                                                     TelemetryClient telemetryClient, Callback httpCallback) {
     MapboxTelemetry.applicationContext = context;
+    MapboxTelemetry.resetAccessToken(context,"");
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    return new MapboxTelemetry(context, accessToken, userAgent,
-      mockedEventsQueue, telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
+    return new MapboxTelemetry(context, accessToken, mockedEventsQueue,
+      telemetryClient, httpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
   }
 

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxTelemetryTest.java
@@ -44,8 +44,7 @@ public class MapboxTelemetryTest {
   public void checksNonNullContextRequired() throws Exception {
     MapboxTelemetry.applicationContext = null;
     String anyAccessToken = "anyAccessToken";
-    String anyUserAgent = "anyUserAgent";
-    new MapboxTelemetry(null, anyAccessToken, anyUserAgent);
+    new MapboxTelemetry(null, anyAccessToken);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -54,8 +53,7 @@ public class MapboxTelemetryTest {
     Context nullApplicationContext = mock(Context.class);
     when(nullApplicationContext.getApplicationContext()).thenReturn(null);
     String anyAccessToken = "anyAccessToken";
-    String anyUserAgent = "anyUserAgent";
-    new MapboxTelemetry(nullApplicationContext, anyAccessToken, anyUserAgent);
+    new MapboxTelemetry(nullApplicationContext, anyAccessToken);
   }
 
   @Test
@@ -548,7 +546,7 @@ public class MapboxTelemetryTest {
   private MapboxTelemetry obtainMapboxTelemetryWith(Context context, String accessToken,
                                                     TelemetryClient telemetryClient, Callback httpCallback) {
     MapboxTelemetry.applicationContext = context;
-    MapboxTelemetry.resetAccessToken(context,"");
+    MapboxTelemetry.clearAccessToken(context);
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/VisionEventFactoryTest.java
@@ -106,15 +106,14 @@ public class VisionEventFactoryTest {
     when(mockedContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mockedAlarmManager);
     MapboxTelemetry.applicationContext = mockedContext;
     String aValidAccessToken = "validAccessToken";
-    String aValidUserAgent = "MapboxTelemetryAndroid/";
     EventsQueue mockedEventsQueue = mock(EventsQueue.class);
     TelemetryClient mockedTelemetryClient = mock(TelemetryClient.class);
     Callback mockedHttpCallback = mock(Callback.class);
     SchedulerFlusher mockedSchedulerFlusher = mock(SchedulerFlusher.class);
     Clock mockedClock = mock(Clock.class);
     TelemetryEnabler telemetryEnabler = new TelemetryEnabler(false);
-    new MapboxTelemetry(mockedContext, aValidAccessToken, aValidUserAgent,
-      mockedEventsQueue, mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
+    new MapboxTelemetry(mockedContext, aValidAccessToken, mockedEventsQueue,
+      mockedTelemetryClient, mockedHttpCallback, mockedSchedulerFlusher, mockedClock,
       telemetryEnabler, mock(ExecutorService.class));
   }
 }


### PR DESCRIPTION
Remove custom user agent and auto generate the user agent to include application information and all Mapbox libraries information according to the following specification.
https://github.com/mapbox/mobile-telemetry/issues/423

Host Application information is read from package information available at run time and Mapbox library information is available in assets folder (https://github.com/mapbox/mapbox-events-android/pull/435). This change reads the information and builds the user agent per format described in the specification
