### PR TITLE
Bump Core and Telemetry versions

### DIFF
--- a/libcore/gradle.properties
+++ b/libcore/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.0-SNAPSHOT
+VERSION_NAME=1.4.1-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-core
 POM_NAME=Mapbox Android Core Library
 POM_DESCRIPTION=Mapbox Android Core Library

--- a/libtelemetry/gradle.properties
+++ b/libtelemetry/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.7.0-SNAPSHOT
+VERSION_NAME=4.7.1-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-telemetry
 POM_NAME=Mapbox Android Telemetry Library
 POM_DESCRIPTION=Mapbox Android Telemetry Library


### PR DESCRIPTION
Set Core/Telem versions in gradle.properties to 1.4.1-SNAPSHOT/4.7.1-SNAPSHOT 