### PR TITLE
Workaround for Strict mode Untagged Socket issue

### DIFF
--- a/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
+++ b/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
@@ -1,2 +1,2 @@
-libcore/1.4.0-SNAPSHOT
+libcore/1.4.1-SNAPSHOT
 v1

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 
 import android.util.Log;
+
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -225,8 +226,16 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
 
   private void initializeTelemetryClient() {
     if (configurationClient == null) {
-      this.configurationClient = new ConfigurationClient(applicationContext,
-        TelemetryUtils.createFullUserAgent(userAgent, applicationContext), sAccessToken.get(), new OkHttpClient());
+      if (BuildConfig.DEBUG) {
+        // Strict mode work around : https://github.com/square/okhttp/issues/3537
+        this.configurationClient = new ConfigurationClient(applicationContext,
+          TelemetryUtils.createFullUserAgent(userAgent, applicationContext), sAccessToken.get(),
+          TelemetryUtils.createOkHttpClientWithStrictModeWorkAround());
+      } else {
+        this.configurationClient = new ConfigurationClient(applicationContext,
+          TelemetryUtils.createFullUserAgent(userAgent, applicationContext), sAccessToken.get(),
+          new OkHttpClient());
+      }
     }
 
     if (certificateBlacklist == null) {

--- a/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
+++ b/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
@@ -1,2 +1,2 @@
-libtelemetry/4.7.0-SNAPSHOT
+libtelemetry/4.7.1-SNAPSHOT
 v1

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -8,12 +8,17 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.TrafficStats;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.support.annotation.Nullable;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -26,6 +31,9 @@ import android.util.Log;
 
 import com.mapbox.android.core.MapboxSdkInfoForUserAgentGenerator;
 
+import javax.net.SocketFactory;
+
+import okhttp3.OkHttpClient;
 import okio.Buffer;
 
 import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES;
@@ -291,5 +299,40 @@ public class TelemetryUtils {
       exception.printStackTrace();
     }
     return false;
+  }
+
+  static OkHttpClient createOkHttpClientWithStrictModeWorkAround() {
+    return new OkHttpClient().newBuilder()
+      .socketFactory(new SocketFactory() {
+        SocketFactory socketFactory = SocketFactory.getDefault();
+        private static final int THREAD_ID = 10000;
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+          TrafficStats.setThreadStatsTag(THREAD_ID);
+          return socketFactory.createSocket(host, port);
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws
+          IOException, UnknownHostException {
+          TrafficStats.setThreadStatsTag(THREAD_ID);
+          return socketFactory.createSocket(host, port, localHost, localPort);
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+          TrafficStats.setThreadStatsTag(THREAD_ID);
+          return socketFactory.createSocket(host, port);
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws
+          IOException {
+          TrafficStats.setThreadStatsTag(THREAD_ID);
+          return socketFactory.createSocket(address, port, localAddress, localPort);
+        }
+      })
+      .build();
   }
 }


### PR DESCRIPTION
Untagged socket detection is one of the anomalies detected by Strict Mode in android from Android O. Since the Telemetry Test app enables the Strict mode with penalty death in debug mode, the app crashes/freezes on installation.
Strict mode expects a tag set to every thread and the threads created by Okhttp sockets does not not seem to do so for different reason. This is still an open issue
https://github.com/square/okhttp/issues/3537

This pull request adds custom socket factory and sets TrafficStats.setThreadStatsTag(1000) for configuration client(okhttpClient). The main Telemetry Client has the similar workaround that already in place.
https://github.com/mapbox/mapbox-events-android/blob/22367f5acbbd27183b7c539a5dd8ba96cb59d159/libtelemetry/src/main/java/com/mapbox/android/telemetry/GzipRequestInterceptor.java#L29