### PR TITLE
Update Gradle Versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 
     pluginVersion = [
             checkstyle       : '8.4',
-            gradle           : '3.4.1',
+            gradle           : '3.5.3',
             dependencyGraph  : '0.5.0',
             mapboxSdkVersions: '1.0.1'
     ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 06 12:04:38 PDT 2019
+#Fri Dec 06 11:54:00 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Update gradle versions to the latest stable releases.

https://developer.android.com/studio/releases/gradle-plugin
Gradle Version : 5.6.4
Android Gradle Plugin Version : 3.5.3