### PR TITLE
Update Node version to >=10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-events-android",
-  "version": "4.0.0",
+  "version": "4.7.1",
   "description": "Telemetry and Location Services",
   "keywords": [
     "mapbox",
@@ -20,7 +20,7 @@
     "pretty-bytes": "^5.1.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {
     "@mapbox/cloudfriend": "^2.5.0"


### PR DESCRIPTION
Node 8 gets to EOL in Dec 2019. It is recommended to update to the latest node version as mentioned here:
https://github.com/mapbox/telemetry/issues/572