### PR TITLE
Update ChangeLog.md for release 4.7.1/1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Mapbox Android Telemetry
 
+## v4.7.1
+
+- Upgrade to AndroidX [#446] (https://github.com/mapbox/mapbox-events-android/pull/446)
+- Revert "Add test device for CI in release process [#449] (https://github.com/mapbox/mapbox-events-android/pull/449)
+- Add test device for CI in release process  [#417] (https://github.com/mapbox/mapbox-events-android/pull/417)
+- Workaround for Strict mode socket issue [#443] (https://github.com/mapbox/mapbox-events-android/pull/443)
+- Update Node version to >=10 [#445] (https://github.com/mapbox/mapbox-events-android/pull/445))
+- Update Gradle Versions [#444] (https://github.com/mapbox/mapbox-events-android/pull/444)
+
+-
 ## v4.7.0
 - Fix crash `setBaseUrl()` on null `TelemetryClient` [#423](https://github.com/mapbox/mapbox-events-android/pull/423)
 - Remove all location permissions from sdk manifest [#430] (https://github.com/mapbox/mapbox-events-android/pull/430)
@@ -227,6 +237,15 @@ Mapbox welcomes participation and contributions from everyone.
 
 
 ## Mapbox Android Core
+
+### v1.4.1
+
+- Upgrade to AndroidX [#446] (https://github.com/mapbox/mapbox-events-android/pull/446)
+- Revert "Add test device for CI in release process [#449] (https://github.com/mapbox/mapbox-events-android/pull/449)
+- Add test device for CI in release process  [#417] (https://github.com/mapbox/mapbox-events-android/pull/417)
+- Workaround for Strict mode socket issue [#443] (https://github.com/mapbox/mapbox-events-android/pull/443)
+- Update Node version to >=10 [#445] (https://github.com/mapbox/mapbox-events-android/pull/445))
+- Update Gradle Versions [#444] (https://github.com/mapbox/mapbox-events-android/pull/444)
 
 ### v1.4.0
 - Apply android-sdk-versions-plugin to Telemetry and Core modules [#435] (https://github.com/mapbox/mapbox-events-android/pull/435)


### PR DESCRIPTION
## Telemetry - v4.7.1 
## Core - v1.4.1
- Upgrade to AndroidX [#446] (https://github.com/mapbox/mapbox-events-android/pull/446)
- Revert "Add test device for CI in release process [#449] (https://github.com/mapbox/mapbox-events-android/pull/449)
- Add test device for CI in release process  [#417] (https://github.com/mapbox/mapbox-events-android/pull/417)
- Workaround for Strict mode socket issue [#443] (https://github.com/mapbox/mapbox-events-android/pull/443)
- Update Node version to >=10 [#445] (https://github.com/mapbox/mapbox-events-android/pull/445))
- Update Gradle Versions [#444] (https://github.com/mapbox/mapbox-events-android/pull/444)
