### PR TITLE
Pre Release 5.0.0/2.0.0: Bump version for future releases and update changelog.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Mapbox Android Telemetry
 
+## v5.0.0
+- Revert "Transition JobIntentService to WorkManager (#453)
+
 ## v4.7.3
 - Fix Turnstile Obfuscation [#457] (https://github.com/mapbox/mapbox-events-android/pull/457)
 
@@ -241,6 +244,9 @@ Mapbox welcomes participation and contributions from everyone.
 
 
 ## Mapbox Android Core
+
+### V2.0.0
+- No Changes. Align the major release with Telemetry.
 
 ### v1.4.1
 

--- a/libcore/gradle.properties
+++ b/libcore/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.0-SNAPSHOT
+VERSION_NAME=2.0.1-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-core
 POM_NAME=Mapbox Android Core Library
 POM_DESCRIPTION=Mapbox Android Core Library

--- a/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
+++ b/libcore/src/main/assets/sdk_versions/com.mapbox.android.core
@@ -1,2 +1,2 @@
-libcore/2.0.0-SNAPSHOT
+libcore/2.0.1-SNAPSHOT
 v1

--- a/libtelemetry/gradle.properties
+++ b/libtelemetry/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.0.0-SNAPSHOT
+VERSION_NAME=5.0.1-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-telemetry
 POM_NAME=Mapbox Android Telemetry Library
 POM_DESCRIPTION=Mapbox Android Telemetry Library

--- a/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
+++ b/libtelemetry/src/main/assets/sdk_versions/com.mapbox.android.telemetry
@@ -1,2 +1,2 @@
-libtelemetry/5.0.0-SNAPSHOT
+libtelemetry/5.0.1-SNAPSHOT
 v1


### PR DESCRIPTION
Bump version to 5.0.1-SNAPSHOT for Telemetry
Bump version to 2.0.1-SNAPSHOT for Core.
Update changelog.md .