### PR TITLE
Fix a crash on newer android OS due to a depreacted API usage

### DIFF
--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TestCellularNetworkType.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TestCellularNetworkType.java
@@ -1,0 +1,16 @@
+package com.mapbox.android.telemetry;
+
+import android.content.Context;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCellularNetworkType {
+  @Test
+  public void testCellularNetworkType() {
+    Context context = InstrumentationRegistry.getInstrumentation().getContext();
+    String cellularNetworkType = TelemetryUtils.obtainCellularNetworkType(context);
+    Assert.assertFalse(cellularNetworkType.isEmpty());
+  }
+}

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -1,5 +1,6 @@
 package com.mapbox.android.telemetry;
 
+import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
@@ -11,6 +12,8 @@ import android.content.pm.PackageManager;
 import android.net.TrafficStats;
 import android.os.BatteryManager;
 import android.os.Build;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
@@ -160,9 +163,23 @@ public class TelemetryUtils {
     return pluggedIntoUSB || pluggedIntoAC;
   }
 
+  @SuppressLint("MissingPermission")
+  @NonNull
   public static String obtainCellularNetworkType(Context context) {
     TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-    return NETWORKS.get(telephonyManager.getNetworkType());
+    int output = TelephonyManager.NETWORK_TYPE_UNKNOWN;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      try {
+        output = telephonyManager.getDataNetworkType();
+      } catch (SecurityException se) {
+        // Developer did not add READ_PHONE_STATE permission to their app
+        // or user did not accept the permission.
+        Log.e(TAG, se.toString());
+      }
+    } else {
+      output = telephonyManager.getNetworkType();
+    }
+    return NETWORKS.get(output);
   }
 
   public static String obtainCurrentDate() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
@@ -37,7 +37,7 @@ public class SchemaTest {
    * but not incorporated into the Android SDK yet.
    **/
   private String[] additionalLocationProperties =
-    {"speed", "course", "floor", "speedAccuracy", "courseAccuracy", "verticalAccuracy"};
+    {"speed", "course", "floor", "speedAccuracy", "courseAccuracy", "verticalAccuracy", "config"};
 
   @BeforeClass
   public static void downloadSchema() throws Exception {


### PR DESCRIPTION
TelephonyManager.getNetworkType() is deprecated in API level 30, so
using getDataNetworkType() to get the current data network type on
newer android OS.

Co-authored-by: Tobrun Van Nuland <tobrun.van.nuland@gmail.com>