### PR TITLE
[telemetry, test] Exclude mapboxAgent field for testing

### DIFF
--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
@@ -207,6 +207,7 @@ public class SchemaTest {
         }
 
         schema.remove("userAgent");
+        schema.remove("mapboxAgent");
         schema.remove("received");
         schema.remove("token");
         schema.remove("authorization");


### PR DESCRIPTION
We don't test at the moment any `userAgent` values, let's do the same for `mapboxAgent` field.