### PR TITLE
[telemetry] Use asterisks for domain matching in CertificatePinner

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/ComCertificatePins.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/ComCertificatePins.java
@@ -10,7 +10,7 @@ class ComCertificatePins {
 
   static final Map<String, List<String>> CERTIFICATE_PINS = new HashMap<String, List<String>>() {
     {
-      put("events.mapbox.com", new ArrayList<String>() {
+      put("**.mapbox.com", new ArrayList<String>() {
         {
           add("BhynraKizavqoC5U26qgYuxLZst6pCu9J5stfL6RSYY=");
           add("owrR9U9FWDWtrFF+myoRIu75JwU4sJwzvhCNLZoY37g=");
@@ -71,10 +71,6 @@ class ComCertificatePins {
           add("QMMBDJh3g1QgkGV6m+T4i2weBGj/W2+fVG73slK3mJE=");
           add("ENU8M1yItdL5EP0G+I4hz4iuGlAUIHWCe4ipwXB/c/A=");
           add("PA1lecwXNRXY/Vpy0VN+jQEYChN4hCAF36oB0Ygx3wQ=");
-        }
-      });
-      put("FVQ3CP/SEI8eLPxHJnjyew2P5DTC1OBKK4Y6XkmC0WI=", new ArrayList<String>() {
-        {
           add("qjl/5X6sDeDCP4DEcR4VFPw0qa/El98EU/ZHwY0jTx0=");
           add("Xw7GYmoUa7YVrYJj7t7RnqYcO58dRFLYEL7UEOuIlX8=");
         }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/CertificatePinnerFactoryTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/CertificatePinnerFactoryTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import static org.junit.Assert.assertTrue;
 
 public class CertificatePinnerFactoryTest {
+  private static final String MAPBOX_COM = "**.mapbox.com";
 
   @Test
   public void checksStagingHostname() throws Exception {
@@ -40,7 +41,7 @@ public class CertificatePinnerFactoryTest {
     Map<String, List<String>> comCertificatesPins = certificatePinnerFactory
       .provideCertificatesPinsFor(Environment.COM);
 
-    assertTrue(comCertificatesPins.containsKey("events.mapbox.com"));
+    assertTrue(comCertificatesPins.containsKey(MAPBOX_COM));
   }
 
   @Test
@@ -50,8 +51,8 @@ public class CertificatePinnerFactoryTest {
     Map<String, List<String>> comCertificatesPins = certificatePinnerFactory
       .provideCertificatesPinsFor(Environment.COM);
 
-    assertTrue(comCertificatesPins.containsKey("events.mapbox.com"));
-    List<String> stagingPins = comCertificatesPins.get("events.mapbox.com");
+    assertTrue(comCertificatesPins.containsKey(MAPBOX_COM));
+    List<String> stagingPins = comCertificatesPins.get(MAPBOX_COM);
     assertTrue(stagingPins.contains("BhynraKizavqoC5U26qgYuxLZst6pCu9J5stfL6RSYY="));
     assertTrue(stagingPins.contains("owrR9U9FWDWtrFF+myoRIu75JwU4sJwzvhCNLZoY37g="));
     assertTrue(stagingPins.contains("SQVGZiOrQXi+kqxcvWWE96HhfydlLVqFr4lQTqI5qqo="));
@@ -65,8 +66,8 @@ public class CertificatePinnerFactoryTest {
     Map<String, List<String>> comCertificatesPins = certificatePinnerFactory
       .provideCertificatesPinsFor(Environment.COM);
 
-    assertTrue(comCertificatesPins.containsKey("events.mapbox.com"));
-    List<String> stagingPins = comCertificatesPins.get("events.mapbox.com");
+    assertTrue(comCertificatesPins.containsKey(MAPBOX_COM));
+    List<String> stagingPins = comCertificatesPins.get(MAPBOX_COM);
     assertTrue(stagingPins.contains("Tb0uHZ/KQjWh8N9+CZFLc4zx36LONQ55l6laDi1qtT4="));
     assertTrue(stagingPins.contains("RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho="));
     assertTrue(stagingPins.contains("WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="));


### PR DESCRIPTION
Okhttp allows to use asterisks for domain matching like:
`**.square.com` for matching all subdomains. We can do the same to avoid
having the list of different domains for pinning certificates.