### PR TITLE
[telemetry] Add foreground/background information to location events.

### DIFF
--- a/libtelemetry/src/full/AndroidManifest.xml
+++ b/libtelemetry/src/full/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.GET_TASKS" android:maxSdkVersion="20"/>
+
     <application>
         <provider
             android:name=".provider.MapboxTelemetryInitProvider"

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationMapper.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationMapper.java
@@ -2,7 +2,6 @@ package com.mapbox.android.telemetry.location;
 
 import android.location.Location;
 import com.mapbox.android.telemetry.LocationEvent;
-
 import java.math.BigDecimal;
 
 public class LocationMapper {
@@ -15,14 +14,13 @@ public class LocationMapper {
     sessionIdentifier = new SessionIdentifier();
   }
 
+  @Deprecated
   public static LocationEvent create(Location location, String sessionId) {
-    // We don't necessarily want to poke activity manager for every single location
-    // update to fetch app state, cause it's extremely expensive to do so on main thread
-    // and we're not making use of appState internally.
-    // Going forward app state changes will be observed by metrics client and can be
-    // correlated with location events via session id.
-    // Since api-events won't accept empty string, default state to unknown
     return createLocationEvent(location, "unknown", sessionId);
+  }
+
+  public static LocationEvent create(Location location, String applicationState, String sessionId) {
+    return createLocationEvent(location, applicationState, sessionId);
   }
 
   public LocationEvent from(Location location, String applicationState) {

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationUpdatesBroadcastReceiver.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationUpdatesBroadcastReceiver.java
@@ -1,10 +1,15 @@
 package com.mapbox.android.telemetry.location;
 
+import android.app.ActivityManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
+import android.os.Build;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+
 import com.mapbox.android.core.location.LocationEngineResult;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 
@@ -18,6 +23,79 @@ public class LocationUpdatesBroadcastReceiver extends BroadcastReceiver {
   private static final String TAG = "LocationUpdateReceiver";
   static final String ACTION_LOCATION_UPDATED =
     "com.mapbox.android.telemetry.location.locationupdatespendingintent.action.LOCATION_UPDATED";
+  private ActivityManager activityManager;
+  private String appPackageName;
+
+  enum AppState {
+    UNKNOWN,
+    FOREGROUND,
+    BACKGROUND;
+
+    @Override
+    public String toString() {
+      switch (this) {
+        case FOREGROUND: return  "Foreground";
+        case BACKGROUND: return  "Background";
+        default:         return  "Unknown";
+      }
+    }
+  }
+
+  private AppState getAppStatePreLollipop() {
+    AppState state = AppState.UNKNOWN;
+    final int maxNumTasksToAsk = 32;
+
+    List<ActivityManager.RunningTaskInfo> tasks =
+            activityManager.getRunningTasks(maxNumTasksToAsk);
+
+    for (ActivityManager.RunningTaskInfo task : tasks) {
+      if (task.topActivity != null) {
+        if (task.topActivity.getPackageName().equals(appPackageName)) {
+          state = AppState.FOREGROUND;
+        }
+      }
+    }
+
+    if ((tasks.size() < maxNumTasksToAsk) && state == AppState.UNKNOWN) {
+      state = AppState.BACKGROUND;
+    }
+
+    return state;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private AppState getAppStateLollipopAndHigher() {
+    AppState state = AppState.BACKGROUND;
+    List<ActivityManager.AppTask> tasks = activityManager.getAppTasks();
+    for (ActivityManager.AppTask task : tasks) {
+      if (task.getTaskInfo().id != -1) {
+        state = AppState.FOREGROUND;
+      }
+    }
+    return state;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  private AppState getAppStateQAndHigher() {
+    AppState state = AppState.BACKGROUND;
+    List<ActivityManager.AppTask> tasks = activityManager.getAppTasks();
+    for (ActivityManager.AppTask task : tasks) {
+      if (task.getTaskInfo().isRunning) {
+        state = AppState.FOREGROUND;
+      }
+    }
+    return state;
+  }
+
+  private AppState getAppState() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      return getAppStateQAndHigher();
+    }
+    if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+      return getAppStateLollipopAndHigher();
+    }
+    return getAppStatePreLollipop();
+  }
 
   @Override
   public void onReceive(Context context, Intent intent) {
@@ -26,6 +104,10 @@ public class LocationUpdatesBroadcastReceiver extends BroadcastReceiver {
         Log.w(TAG, "intent == null");
         return;
       }
+
+      activityManager =
+              (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+      appPackageName = context.getApplicationContext().getPackageName();
 
       final String action = intent.getAction();
       if (!ACTION_LOCATION_UPDATED.equals(action)) {
@@ -46,7 +128,8 @@ public class LocationUpdatesBroadcastReceiver extends BroadcastReceiver {
         if (isThereAnyNaN(location) || isThereAnyInfinite(location)) {
           continue;
         }
-        telemetry.push(LocationMapper.create(location, sessionId));
+        final String appState = getAppState().toString();
+        telemetry.push(LocationMapper.create(location, appState, sessionId));
       }
     } catch (Throwable throwable) {
       // TODO: log silent crash

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/location/LocationUpdatesBroadcastReceiverTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/location/LocationUpdatesBroadcastReceiverTest.java
@@ -12,7 +12,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -40,7 +39,6 @@ public class LocationUpdatesBroadcastReceiverTest {
   public void testOnReceiveActionReturnNull() {
     Context mockedContext = mock(Context.class, RETURNS_DEEP_STUBS);
     Intent mockedIntent = mock(Intent.class);
-    when(mockedIntent.getAction()).thenReturn(null);
     broadcastReceiver.onReceive(mockedContext, mockedIntent);
     verify(mockedIntent, never()).getStringExtra(anyString());
   }


### PR DESCRIPTION
Get and send the background/foreground state of an application in location events.

Fixes https://github.com/mapbox/core-sdk-team/issues/525