### PR TITLE
telemetry-6.2.2-core-3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### devel
 
+### v6.2.2
+
+`telemetry-6.2.2-core-3.1.1` -
+
+- [telemetry] track foreground and background application states and send with events
+- [core] LocationEngineRequest supports Equality and Hashing
+
 ### v6.2.1
 - [telemetry] Use asterisks for domain matching in CertificatePinner [#503](https://github.com/mapbox/mapbox-events-android/pull/503)
 

--- a/libcore/gradle.properties
+++ b/libcore/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.1.1-SNAPSHOT
+VERSION_NAME=3.1.2-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-core
 POM_NAME=Mapbox Android Core Library
 POM_DESCRIPTION=Mapbox Android Core Library

--- a/libtelemetry/gradle.properties
+++ b/libtelemetry/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=6.2.2-SNAPSHOT
+VERSION_NAME=6.2.3-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-telemetry
 POM_NAME=Mapbox Android Telemetry Library
 POM_DESCRIPTION=Mapbox Android Telemetry Library


### PR DESCRIPTION
`telemetry-6.2.2-core-3.1.1`

- [telemetry] track foreground and background application states and send with events
- [core] LocationEngineRequest supports Equality and Hashing
