### PR TITLE
Non-fatal exceptions reporting

### DIFF
--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportBuilderInstrumentedTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportBuilderInstrumentedTest.java
@@ -7,28 +7,23 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Collections;
 
-import static com.mapbox.android.core.crashreporter.MapboxUncaughtExceptionHanlder.MAPBOX_CRASH_REPORTER_PREFERENCES;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class CrashReportBuilderInstrumentedTest {
-  private final String validJson = "{\"query\":\"Pizza\",\"locations\":[94043,90210]}";
+  private final String validJson = "{\"locations\":[94043,90210],\"query\":\"Pizza\"}";
   private static final String TELEM_MAPBOX_PACKAGE = "com.mapbox.android.telemetry";
   private static final String TELEM_MAPBOX_VERSION = "4.0.0";
 
-  private MapboxUncaughtExceptionHanlder exceptionHanlder;
   private CrashReportBuilder builder;
 
   @Before
   public void setUp() {
     Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-    exceptionHanlder = new MapboxUncaughtExceptionHanlder(context,
-        context.getSharedPreferences(MAPBOX_CRASH_REPORTER_PREFERENCES, Context.MODE_PRIVATE),
-        TELEM_MAPBOX_PACKAGE, TELEM_MAPBOX_VERSION, Thread.getDefaultUncaughtExceptionHandler());
-    builder = CrashReportBuilder.setup(context, TELEM_MAPBOX_PACKAGE, TELEM_MAPBOX_VERSION);
+    builder = CrashReportBuilder.setup(context, TELEM_MAPBOX_PACKAGE,
+      TELEM_MAPBOX_VERSION, Collections.<String>emptySet());
   }
 
   @After
@@ -48,66 +43,11 @@ public class CrashReportBuilderInstrumentedTest {
   }
 
   @Test
-  public void checkMandatoryAttributes() {
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(createMapboxThrowable());
-    CrashReport report = builder
-      .addExceptionThread(Thread.currentThread())
-      .addCausalChain(causalChain)
-      .build();
-
-    assertEquals("mobile.crash", report.getString("event"));
-    assertFalse(report.getString("created").isEmpty());
-  }
-
-  @Test
   public void buildOffDefaults() {
     try {
       builder.build();
     } catch (Exception npe) {
       fail("Unexpected exception: " + npe.toString());
     }
-  }
-
-  @Test
-  public void getStackTrace() {
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(createMapboxThrowable());
-    String stackTrace = builder.getStackTrace(causalChain);
-    assertEquals("com.mapbox.android.telemetry.A.foo(com.mapbox.android.telemetry.A.java:0)\n", stackTrace);
-  }
-
-  @Test
-  public void checkStackTraceHash() {
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(createMapboxThrowable());
-    String hash = CrashReportBuilder.getStackTraceHash(causalChain);
-    assertEquals("34cbd8fe", hash);
-  }
-
-  @Test
-  public void checkFullStackTraceHash() {
-    exceptionHanlder.setExceptionChainDepth(1);
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(createMapboxThrowable());
-    String hash = CrashReportBuilder.getStackTraceHash(causalChain);
-    assertEquals("941ea8f5", hash);
-  }
-
-  private static Throwable createMapboxThrowable() {
-    Throwable highLevelThrowable = createThrowable("HighLevelThrowable", "A", "B");
-    Throwable midLevelThrowable = createThrowable("MidLevelThrowable", "A", "B", "C", "D");
-    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
-      TELEM_MAPBOX_PACKAGE + ".A", "F", "G"));
-    highLevelThrowable.initCause(midLevelThrowable);
-    return highLevelThrowable;
-  }
-
-  private static Throwable createThrowable(String message, String... stackTraceElements) {
-    StackTraceElement[] array = new StackTraceElement[stackTraceElements.length];
-    for (int i = 0; i < stackTraceElements.length; i++) {
-      String s = stackTraceElements[i];
-      array[stackTraceElements.length - 1 - i]
-        = new StackTraceElement(s, "foo", s + ".java", i);
-    }
-    Throwable result = new Throwable(message);
-    result.setStackTrace(array);
-    return result;
   }
 }

--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportFactoryInstrumentedTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportFactoryInstrumentedTest.java
@@ -1,0 +1,169 @@
+package com.mapbox.android.core.crashreporter;
+
+import android.content.Context;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CrashReportFactoryInstrumentedTest {
+  private static final String TELEM_MAPBOX_PACKAGE = "com.mapbox.android.telemetry";
+  private static final String TELEM_MAPBOX_VERSION = "4.0.0";
+
+  private static final String JAVA_UTIL_PACKAGE = "java.util";
+  private static final Set<String> ALLOWED_PACKAGE_PREFIXES = new HashSet<>();
+
+  static  {
+    ALLOWED_PACKAGE_PREFIXES.add(JAVA_UTIL_PACKAGE);
+  }
+
+  private CrashReportFactory factory;
+
+  @Before
+  public void setUp() {
+    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    factory = new CrashReportFactory(context, TELEM_MAPBOX_PACKAGE, TELEM_MAPBOX_VERSION,
+      ALLOWED_PACKAGE_PREFIXES);
+  }
+
+  @After
+  public void tearDown() {
+    factory = null;
+  }
+
+  @Test
+  public void checkMandatoryAttributesForCrash() {
+    CrashReport report = factory.createReportForCrash(Thread.currentThread(), createMapboxThrowable());
+
+    assertNotNull(report);
+    assertEquals("mobile.crash", report.getString("event"));
+    assertFalse(report.getString("created").isEmpty());
+  }
+
+  @Test
+  public void checkMandatoryAttributesForNonFatal() {
+    CrashReport report = factory.createReportForNonFatal(createMapboxThrowable());
+
+    assertNotNull(report);
+    assertEquals("mobile.crash", report.getString("event"));
+    assertFalse(report.getString("created").isEmpty());
+  }
+
+  @Test
+  public void getStackTrace() {
+    factory.setCrashChainDepth(2);
+    CrashReport report = factory.createReportForCrash(Thread.currentThread(), createMapboxThrowable());
+
+    assertNotNull(report);
+    assertEquals("***\n"
+        + "*\n"
+        + "*\n"
+        + "*\n"
+        + "*\n"
+        + "***\n"
+        + "*\n"
+        + "*\n"
+        + "com.mapbox.android.telemetry.A.foo(com.mapbox.android.telemetry.A.java:0)\n",
+      report.getString("stackTrace"));
+  }
+
+
+  @Test
+  public void checkStackTraceHashForCrash() {
+    factory.setCrashChainDepth(2);
+    CrashReport report = factory.createReportForCrash(Thread.currentThread(), createMapboxThrowable());
+
+    assertNotNull(report);
+    assertEquals("34cbd8fe", report.getString("stackTraceHash"));
+  }
+
+  @Test
+  public void checkStackTraceHashForNonFatal() {
+    CrashReport report = factory.createReportForNonFatal(createMapboxThrowable());
+
+    assertNotNull(report);
+    assertEquals("941ea8f5", report.getString("stackTraceHash"));
+  }
+
+  @Test
+  public void checkStackTraceWithAllowedPackagesCrash() {
+    factory.setCrashChainDepth(2);
+    Throwable highLevelThrowable = createThrowable("HighLevelThrowable",
+      JAVA_UTIL_PACKAGE + ".A", JAVA_UTIL_PACKAGE + ".B");
+    Throwable midLevelThrowable = createThrowable("MidLevelThrowable",
+      "A", "B", "C");
+    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
+      TELEM_MAPBOX_PACKAGE + ".A", "D", "E"));
+    highLevelThrowable.initCause(midLevelThrowable);
+
+    CrashReport report = factory.createReportForCrash(Thread.currentThread(), highLevelThrowable);
+
+    assertNotNull(report);
+    assertEquals("***\n"
+        + "*\n"
+        + "*\n"
+        + "*\n"
+        + "***\n"
+        + "*\n"
+        + "*\n"
+        + "com.mapbox.android.telemetry.A.foo(com.mapbox.android.telemetry.A.java:0)\n",
+      report.getString("stackTrace"));
+  }
+
+  @Test
+  public void checkStackTraceWithAllowedPackagesNonFatal() {
+    Throwable highLevelThrowable = createThrowable("HighLevelThrowable",
+      JAVA_UTIL_PACKAGE + ".A", JAVA_UTIL_PACKAGE + ".B");
+    Throwable midLevelThrowable = createThrowable("MidLevelThrowable",
+      "A", "B", "C");
+    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
+      TELEM_MAPBOX_PACKAGE + ".A", "D", "E"));
+    highLevelThrowable.initCause(midLevelThrowable);
+
+    CrashReport report = factory.createReportForNonFatal(highLevelThrowable);
+
+    assertNotNull(report);
+    assertEquals("HighLevelThrowable\n"
+        + "java.util.B.foo(java.util.B.java:1)\n"
+        + "java.util.A.foo(java.util.A.java:0)\n"
+        + "***\n"
+        + "*\n"
+        + "*\n"
+        + "*\n"
+        + "***\n"
+        + "*\n"
+        + "*\n"
+        + "com.mapbox.android.telemetry.A.foo(com.mapbox.android.telemetry.A.java:0)\n",
+      report.getString("stackTrace"));
+  }
+
+  private static Throwable createMapboxThrowable() {
+    Throwable highLevelThrowable = createThrowable("HighLevelThrowable", "A", "B");
+    Throwable midLevelThrowable = createThrowable("MidLevelThrowable", "A", "B", "C", "D");
+    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
+      TELEM_MAPBOX_PACKAGE + ".A", "F", "G"));
+    highLevelThrowable.initCause(midLevelThrowable);
+    return highLevelThrowable;
+  }
+
+  private static Throwable createThrowable(String message, String... stackTraceElements) {
+    StackTraceElement[] array = new StackTraceElement[stackTraceElements.length];
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      String s = stackTraceElements[i];
+      array[stackTraceElements.length - 1 - i]
+        = new StackTraceElement(s, "foo", s + ".java", i);
+    }
+    Throwable result = new Throwable(message);
+    result.setStackTrace(array);
+    return result;
+  }
+}

--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderInstrumentationTest.java
@@ -56,7 +56,7 @@ public class MapboxUncaughtExceptionHanlderInstrumentationTest {
   @Test
   public void testReportCap() throws IOException {
     writeToDisk(10);
-    exceptionHanlder.setExceptionChainDepth(1);
+    exceptionHanlder.crashReportFactory.setCrashChainDepth(1);
     exceptionHanlder.uncaughtException(Thread.currentThread(), createMapboxThrowable());
 
     File[] files = directory.listFiles();

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReportFactory.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReportFactory.java
@@ -1,0 +1,126 @@
+package com.mapbox.android.core.crashreporter;
+
+import android.content.Context;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Factory for creating {@link CrashReport}.
+ */
+public final class CrashReportFactory {
+  private static final int DEFAULT_CRASH_CHAIN_DEPTH = 2;
+  private static final int DEFAULT_NON_FATAL_ERROR_CHAIN_DEPTH = 1;
+
+  private final Context applicationContext;
+  private final String mapboxPackage;
+  private final String mapboxModuleVersion;
+  private final Set<String> allowedStacktracePrefixes;
+
+  private int crashChainDepth;
+
+  public CrashReportFactory(Context applicationContext, String mapboxPackage, String mapboxModuleVersion,
+                            Set<String> allowedStacktracePrefixes) {
+    this.applicationContext = applicationContext;
+    this.mapboxPackage = mapboxPackage;
+    this.mapboxModuleVersion = mapboxModuleVersion;
+    this.allowedStacktracePrefixes = allowedStacktracePrefixes;
+    crashChainDepth = DEFAULT_CRASH_CHAIN_DEPTH;
+  }
+
+  /**
+   * Create {@link CrashReport} for crash.
+   *
+   * @param thread thread, where exception has occurred
+   * @param throwable crash itself
+   * @return report, if crash was partly or fully caused by Mapbox module/sdk with
+   *         {@linkplain CrashReportFactory#mapboxPackage} package name; otherwise, null
+   *         is returned
+   */
+  @Nullable
+  public CrashReport createReportForCrash(Thread thread, Throwable throwable) {
+    CrashReport report = null;
+
+    List<Throwable> causalChain;
+    if (isMapboxCrash(causalChain = getCausalChain(throwable, crashChainDepth))) {
+      report = CrashReportBuilder
+        .setup(applicationContext, mapboxPackage, mapboxModuleVersion, allowedStacktracePrefixes)
+        .addExceptionThread(thread)
+        .addCausalChain(causalChain)
+        .build();
+    }
+
+    return report;
+  }
+
+  /**
+   * Create {@link CrashReport} for non-fatal error.
+   *
+   * @param throwable non-fatal error
+   * @return report, if non-fatal error was partly or fully caused by Mapbox module/sdk with
+   *         {@linkplain CrashReportFactory#mapboxPackage} package name; otherwise, null
+   *         is returned
+   */
+  @Nullable
+  public CrashReport createReportForNonFatal(Throwable throwable) {
+    CrashReport report = null;
+
+    List<Throwable> causalChain;
+    if (isMapboxCrash(causalChain = getCausalChain(throwable, DEFAULT_NON_FATAL_ERROR_CHAIN_DEPTH))) {
+      report = CrashReportBuilder
+        .setup(applicationContext, mapboxPackage, mapboxModuleVersion, allowedStacktracePrefixes)
+        .isSilent(true)
+        .addCausalChain(causalChain)
+        .build();
+    }
+
+    return report;
+  }
+
+  /**
+   * Set exception chain depth we're interested in to dig into backtrace data.
+   *
+   * @param depth of exception chain
+   */
+  @VisibleForTesting
+  void setCrashChainDepth(@IntRange(from = 1, to = 256) int depth) {
+    this.crashChainDepth = depth;
+  }
+
+  @VisibleForTesting
+  boolean isMapboxCrash(List<Throwable> throwables) {
+    for (Throwable cause : throwables) {
+      final StackTraceElement[] stackTraceElements = cause.getStackTrace();
+      for (final StackTraceElement element : stackTraceElements) {
+        if (isMapboxStackTraceElement(element)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @VisibleForTesting
+  List<Throwable> getCausalChain(@Nullable Throwable throwable, int causeDepth) {
+    List<Throwable> causes = new ArrayList<>(4);
+    int level = 0;
+    while (throwable != null) {
+      if (++level >= causeDepth) {
+        causes.add(throwable);
+      }
+      throwable = throwable.getCause();
+    }
+    return Collections.unmodifiableList(causes);
+  }
+
+  private boolean isMapboxStackTraceElement(@NonNull StackTraceElement element) {
+    return element.getClassName().startsWith(mapboxPackage);
+  }
+}

--- a/libcore/src/test/java/com/mapbox/android/core/crashreporter/CrashReportFactoryTest.java
+++ b/libcore/src/test/java/com/mapbox/android/core/crashreporter/CrashReportFactoryTest.java
@@ -1,0 +1,115 @@
+package com.mapbox.android.core.crashreporter;
+
+import android.content.Context;
+
+import com.mapbox.android.core.utils.NoStackTraceException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static com.mapbox.android.core.utils.ErrorTestUtils.createMapboxThrowable;
+import static com.mapbox.android.core.utils.ErrorTestUtils.createThrowable;
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CrashReportFactoryTest {
+  private static final String TELEM_MAPBOX_PACKAGE = "com.mapbox.android.telemetry";
+  private static final String TELEM_MAPBOX_VERSION = "4.0.0";
+
+  @Mock
+  private Context context;
+
+  private CrashReportFactory crashReportFactory;
+
+  @Before
+  public void setUp() {
+    crashReportFactory = new CrashReportFactory(context, TELEM_MAPBOX_PACKAGE,
+      TELEM_MAPBOX_VERSION, Collections.<String>emptySet());
+  }
+
+  @After
+  public void tearDown() {
+    reset(context);
+    crashReportFactory = null;
+  }
+
+  @Test
+  public void testCrashNullStackTrace() {
+    crashReportFactory.setCrashChainDepth(1);
+    try {
+      crashReportFactory.createReportForCrash(Thread.currentThread(), new NoStackTraceException());
+    } catch (Throwable throwable) {
+      fail("Unexpected assertion due to null stacktrace: " + throwable.toString());
+    }
+  }
+
+  @Test
+  public void testNonFatalNullStackTrace() {
+    try {
+      crashReportFactory.createReportForNonFatal(new NoStackTraceException());
+    } catch (Throwable throwable) {
+      fail("Unexpected assertion due to null stacktrace: " + throwable.toString());
+    }
+  }
+
+  @Test
+  public void testHighLevelCrash() {
+    crashReportFactory.setCrashChainDepth(2);
+    Throwable throwable = createThrowable("HighLevelThrowable", "A", "B");
+    CrashReport crashReport = crashReportFactory.createReportForCrash(Thread.currentThread(), throwable);
+    assertThat(crashReport).isNull();
+  }
+
+  @Test
+  public void testHighLevelNonFatal() {
+    Throwable throwable = createThrowable("HighLevelThrowable", "A", "B");
+    CrashReport crashReport = crashReportFactory.createReportForNonFatal(throwable);
+    assertThat(crashReport).isNull();
+  }
+
+  @Test
+  public void testMidLevelCrash() {
+    crashReportFactory.setCrashChainDepth(2);
+    Throwable throwable = createMapboxThrowable(TELEM_MAPBOX_PACKAGE);
+    CrashReport crashReport = crashReportFactory.createReportForCrash(null, throwable);
+    assertThat(crashReport).isNotNull();
+  }
+
+  @Test
+  public void testMidLevelNonFatal() {
+    Throwable throwable = createMapboxThrowable(TELEM_MAPBOX_PACKAGE);
+    CrashReport crashReport = crashReportFactory.createReportForNonFatal(throwable);
+    assertThat(crashReport).isNotNull();
+  }
+
+  @Test
+  public void testLowLevelCrash() {
+    crashReportFactory.setCrashChainDepth(2);
+    Throwable highLevelThrowable = createThrowable("HighLevelThrowable", "A", "B");
+    Throwable midLevelThrowable = createThrowable("MidLevelThrowable", "A", "B", "C", "D");
+    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
+      TELEM_MAPBOX_PACKAGE + ".A", "F", "G"));
+    highLevelThrowable.initCause(midLevelThrowable);
+    CrashReport crashReport = crashReportFactory.createReportForCrash(null, highLevelThrowable);
+    assertThat(crashReport).isNotNull();
+  }
+
+  @Test
+  public void testLowLevelNonFatal() {
+    Throwable highLevelThrowable = createThrowable("HighLevelThrowable", "A", "B");
+    Throwable midLevelThrowable = createThrowable("MidLevelThrowable", "A", "B", "C", "D");
+    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
+      TELEM_MAPBOX_PACKAGE + ".A", "F", "G"));
+    highLevelThrowable.initCause(midLevelThrowable);
+    CrashReport crashReport = crashReportFactory.createReportForNonFatal(highLevelThrowable);
+    assertThat(crashReport).isNotNull();
+  }
+}

--- a/libcore/src/test/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderTest.java
+++ b/libcore/src/test/java/com/mapbox/android/core/crashreporter/MapboxUncaughtExceptionHanlderTest.java
@@ -10,8 +10,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
-import java.util.List;
 
+import static com.mapbox.android.core.utils.ErrorTestUtils.createMapboxThrowable;
+import static com.mapbox.android.core.utils.ErrorTestUtils.createThrowable;
 import static com.mapbox.android.core.crashreporter.MapboxUncaughtExceptionHanlder.MAPBOX_PREF_ENABLE_CRASH_REPORTER;
 import static junit.framework.TestCase.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,9 +41,8 @@ public class MapboxUncaughtExceptionHanlderTest {
 
   @Before
   public void setUp() {
-    exceptionHanlder =
-      new MapboxUncaughtExceptionHanlder(context, sharedPreferences, TELEM_MAPBOX_PACKAGE, TELEM_MAPBOX_VERSION,
-        defaultExceptionHanlder);
+    exceptionHanlder = new MapboxUncaughtExceptionHanlder(context, sharedPreferences,
+      TELEM_MAPBOX_PACKAGE, TELEM_MAPBOX_VERSION, defaultExceptionHanlder);
   }
 
   @After
@@ -71,41 +71,19 @@ public class MapboxUncaughtExceptionHanlderTest {
   }
 
   @Test
-  public void testNullStackTrace() {
-    exceptionHanlder.setExceptionChainDepth(1);
-    try {
-      exceptionHanlder.uncaughtException(Thread.currentThread(), new NoStackTraceException());
-    } catch (Throwable throwable) {
-      fail("Unexpected assertion due to null stacktrace: " + throwable.toString());
-    }
+  public void onSharedPreferenceChangedWithInvalidKey() {
+    boolean isEnabled = exceptionHanlder.isEnabled();
+    exceptionHanlder.onSharedPreferenceChanged(getMockedSharedPrefs("FooKey", false), "FooKey");
+    assertThat(exceptionHanlder.isEnabled()).isEqualTo(isEnabled);
   }
 
   @Test
-  public void testHighLevelException() {
-    exceptionHanlder.setExceptionChainDepth(2);
-    Throwable throwable = createThrowable("HighLevelThrowable", "A", "B");
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(throwable);
-    assertThat(exceptionHanlder.isMapboxCrash(causalChain)).isFalse();
-  }
-
-  @Test
-  public void testMidLevelException() {
-    exceptionHanlder.setExceptionChainDepth(2);
-    Throwable throwable = createMapboxThrowable();
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(throwable);
-    assertThat(exceptionHanlder.isMapboxCrash(causalChain)).isTrue();
-  }
-
-  @Test
-  public void testLowLevelException() {
-    exceptionHanlder.setExceptionChainDepth(2);
-    Throwable highLevelThrowable = createThrowable("HighLevelThrowable", "A", "B");
-    Throwable midLevelThrowable = createThrowable("MidLevelThrowable", "A", "B", "C", "D");
-    midLevelThrowable.initCause(createThrowable("LowLevelThrowable",
-      TELEM_MAPBOX_PACKAGE + ".A", "F", "G"));
-    highLevelThrowable.initCause(midLevelThrowable);
-    List<Throwable> causalChain = exceptionHanlder.getCausalChain(highLevelThrowable);
-    assertThat(exceptionHanlder.isMapboxCrash(causalChain)).isTrue();
+  public void onSharedPreferenceChanged() {
+    boolean isEnabled = exceptionHanlder.isEnabled();
+    exceptionHanlder.onSharedPreferenceChanged(
+      getMockedSharedPrefs(MAPBOX_PREF_ENABLE_CRASH_REPORTER, false),
+      MAPBOX_PREF_ENABLE_CRASH_REPORTER);
+    assertThat(exceptionHanlder.isEnabled()).isNotEqualTo(isEnabled);
   }
 
   @Test
@@ -127,58 +105,16 @@ public class MapboxUncaughtExceptionHanlderTest {
 
   @Test
   public void exceptionHandlerEnabledMapboxCrash() {
-    exceptionHanlder.setExceptionChainDepth(2);
+    exceptionHanlder.crashReportFactory.setCrashChainDepth(2);
     when(context.getFilesDir()).thenReturn(new File(""));
-    exceptionHanlder.uncaughtException(Thread.currentThread(), createMapboxThrowable());
+    exceptionHanlder.uncaughtException(Thread.currentThread(), createMapboxThrowable(TELEM_MAPBOX_PACKAGE));
     // FIXME: figure out why these aren't passing on CI
     //verify(context, times(2)).getFilesDir();
-  }
-
-  @Test
-  public void onSharedPreferenceChangedWithInvalidKey() {
-    boolean isEnabled = exceptionHanlder.isEnabled();
-    exceptionHanlder.onSharedPreferenceChanged(getMockedSharedPrefs("FooKey", false), "FooKey");
-    assertThat(exceptionHanlder.isEnabled()).isEqualTo(isEnabled);
-  }
-
-  @Test
-  public void onSharedPreferenceChanged() {
-    boolean isEnabled = exceptionHanlder.isEnabled();
-    exceptionHanlder.onSharedPreferenceChanged(
-      getMockedSharedPrefs(MAPBOX_PREF_ENABLE_CRASH_REPORTER, false),
-      MAPBOX_PREF_ENABLE_CRASH_REPORTER);
-    assertThat(exceptionHanlder.isEnabled()).isNotEqualTo(isEnabled);
-  }
-
-  private static Throwable createMapboxThrowable() {
-    Throwable throwable = createThrowable("HighLevelThrowable", "A", "B");
-    throwable.initCause(createThrowable("MidLevelThrowable",
-      TELEM_MAPBOX_PACKAGE + ".A", "B", "C", "D"));
-    return throwable;
   }
 
   private static SharedPreferences getMockedSharedPrefs(String key, boolean value) {
     SharedPreferences sharedPreferences = mock(SharedPreferences.class);
     when(sharedPreferences.getBoolean(key, true)).thenReturn(value);
     return sharedPreferences;
-  }
-
-  private static Throwable createThrowable(String message, String... stackTraceElements) {
-    StackTraceElement[] array = new StackTraceElement[stackTraceElements.length];
-    for (int i = 0; i < stackTraceElements.length; i++) {
-      String s = stackTraceElements[i];
-      array[stackTraceElements.length - 1 - i]
-        = new StackTraceElement(s, "foo", s + ".java", i);
-    }
-    Throwable result = new Throwable(message);
-    result.setStackTrace(array);
-    return result;
-  }
-
-  private static class NoStackTraceException extends Exception {
-    @Override
-    public synchronized Throwable fillInStackTrace() {
-      return null;
-    }
   }
 }

--- a/libcore/src/test/java/com/mapbox/android/core/utils/ErrorTestUtils.java
+++ b/libcore/src/test/java/com/mapbox/android/core/utils/ErrorTestUtils.java
@@ -1,0 +1,23 @@
+package com.mapbox.android.core.utils;
+
+public class ErrorTestUtils {
+
+  public static Throwable createMapboxThrowable(String mapboxPackage) {
+    Throwable throwable = createThrowable("HighLevelThrowable", "A", "B");
+    throwable.initCause(createThrowable("MidLevelThrowable",
+      mapboxPackage + ".A", "B", "C", "D"));
+    return throwable;
+  }
+
+  public static Throwable createThrowable(String message, String... stackTraceElements) {
+    StackTraceElement[] array = new StackTraceElement[stackTraceElements.length];
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      String s = stackTraceElements[i];
+      array[stackTraceElements.length - 1 - i]
+        = new StackTraceElement(s, "foo", s + ".java", i);
+    }
+    Throwable result = new Throwable(message);
+    result.setStackTrace(array);
+    return result;
+  }
+}

--- a/libcore/src/test/java/com/mapbox/android/core/utils/NoStackTraceException.java
+++ b/libcore/src/test/java/com/mapbox/android/core/utils/NoStackTraceException.java
@@ -1,0 +1,8 @@
+package com.mapbox.android.core.utils;
+
+public class NoStackTraceException extends Exception {
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return null;
+  }
+}

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
@@ -1,0 +1,55 @@
+package com.mapbox.android.telemetry;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import com.mapbox.android.core.crashreporter.CrashReport;
+import com.mapbox.android.core.crashreporter.CrashReportFactory;
+import com.mapbox.android.telemetry.errors.ErrorUtils;
+
+import java.util.Set;
+
+/**
+ * Class for reporting {@link Throwable} via Telemetry.
+ */
+public class MapboxCrashReporter {
+
+  private final MapboxTelemetry telemetry;
+  private final CrashReportFactory crashReportFactory;
+
+  public MapboxCrashReporter(@NonNull MapboxTelemetry telemetry,
+                             @NonNull String mapboxPackage,
+                             @NonNull String mapboxModuleVersion,
+                             @NonNull Set<String> allowedStacktracePrefixes) {
+    this.telemetry = telemetry;
+    crashReportFactory = new CrashReportFactory(MapboxTelemetry.applicationContext,
+      mapboxPackage, mapboxModuleVersion, allowedStacktracePrefixes);
+  }
+
+  // For testing only
+  MapboxCrashReporter(@NonNull MapboxTelemetry telemetry,
+                      @NonNull CrashReportFactory crashReportFactory) {
+    this.telemetry = telemetry;
+    this.crashReportFactory = crashReportFactory;
+  }
+
+  /**
+   * Report non-fatal exception via Telemetry.
+   *
+   * @param throwable non-fatal error, that should be reported
+   * @return whether error event was added to event queue
+   */
+  public boolean reportError(Throwable throwable) {
+    CrashReport report = crashReportFactory.createReportForNonFatal(throwable);
+    if (report != null) {
+      CrashEvent nonFatalErrorEvent = parseReportAsEvent(report);
+      return telemetry.push(nonFatalErrorEvent);
+    }
+    return false;
+  }
+
+  @VisibleForTesting
+  CrashEvent parseReportAsEvent(CrashReport report) {
+    return ErrorUtils.parseJsonCrashEvent(report.toJson());
+  }
+}

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/errors/ErrorReporterClient.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/errors/ErrorReporterClient.java
@@ -5,9 +5,6 @@ import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import android.util.Log;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
 import com.mapbox.android.core.FileUtils;
 import com.mapbox.android.telemetry.BuildConfig;
 import com.mapbox.android.telemetry.CrashEvent;
@@ -94,7 +91,7 @@ final class ErrorReporterClient {
 
     try {
       File file = crashReports[fileCursor];
-      CrashEvent event = parseJsonCrashEvent(FileUtils.readFromFile(file));
+      CrashEvent event = ErrorUtils.parseJsonCrashEvent(FileUtils.readFromFile(file));
       if (event.isValid()) {
         eventFileHashMap.put(event, file);
       }
@@ -155,15 +152,5 @@ final class ErrorReporterClient {
         telemetry.removeTelemetryListener(this);
       }
     });
-  }
-
-  private static CrashEvent parseJsonCrashEvent(String json) {
-    Gson gson = new GsonBuilder().create();
-    try {
-      return gson.fromJson(json, CrashEvent.class);
-    } catch (JsonSyntaxException jse) {
-      Log.e(LOG_TAG, jse.toString());
-      return new CrashEvent(null, null);
-    }
   }
 }

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/errors/ErrorUtils.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/errors/ErrorUtils.java
@@ -1,0 +1,22 @@
+package com.mapbox.android.telemetry.errors;
+
+import android.util.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.mapbox.android.telemetry.CrashEvent;
+
+public final class ErrorUtils {
+  private static final String LOG_TAG = "ErrorUtils";
+
+  public static CrashEvent parseJsonCrashEvent(String json) {
+    Gson gson = new GsonBuilder().create();
+    try {
+      return gson.fromJson(json, CrashEvent.class);
+    } catch (JsonSyntaxException jse) {
+      Log.e(LOG_TAG, jse.toString());
+      return new CrashEvent(null, null);
+    }
+  }
+}

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
@@ -38,7 +38,13 @@ public class SchemaTest {
    **/
   private String[] additionalLocationProperties =
     {"speed", "course", "floor", "speedAccuracy", "courseAccuracy", "verticalAccuracy", "config",
-     "approximate", "accuracyAuthorization"};
+     "approximate", "accuracyAuthorization", "version"};
+
+  /**
+   * Properties in Vision Schema that are added in backend
+   * but not incorporated into the Android SDK yet.
+   **/
+  private String[] additionalVisionProperties = {"version"};
 
   @BeforeClass
   public static void downloadSchema() throws Exception {
@@ -93,6 +99,12 @@ public class SchemaTest {
   @Test
   public void validateVisionEventFormat() {
     JsonObject schema = grabSchema(VisionObjectDetectionEvent.VIS_OBJECT_DETECTION);
+    if (schema != null) {
+      // Ignore the event properties that are not incorporated into the android sdk yet.
+      for (String string : additionalVisionProperties) {
+        schema.remove(string);
+      }
+    }
     List<Field> fields = grabClassFields(VisionObjectDetectionEvent.class);
     assertEquals(schema.size(), fields.size());
     schemaContainsFields(schema, fields);

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
@@ -1,0 +1,53 @@
+package com.mapbox.android.telemetry;
+
+import com.mapbox.android.core.crashreporter.CrashReport;
+import com.mapbox.android.core.crashreporter.CrashReportFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MapboxCrashReporterTest {
+
+  @Test
+  public void reportNonMapboxException() {
+    MapboxTelemetry telemetryMock = mock(MapboxTelemetry.class);
+    CrashReportFactory reportFactoryMock = mock(CrashReportFactory.class);
+    MapboxCrashReporter reporter = new MapboxCrashReporter(telemetryMock, reportFactoryMock);
+
+    Throwable error = new Exception();
+    when(reportFactoryMock.createReportForNonFatal(error)).thenReturn(null);
+
+    boolean isReported = reporter.reportError(error);
+
+    verify(telemetryMock, never()).push(any(Event.class));
+    Assert.assertFalse(isReported);
+  }
+
+  @Test
+  public void reportMapboxException() {
+    MapboxTelemetry telemetryMock = mock(MapboxTelemetry.class);
+    CrashReportFactory reportFactoryMock = mock(CrashReportFactory.class);
+    MapboxCrashReporter reporter = spy(new MapboxCrashReporter(telemetryMock, reportFactoryMock));
+
+    Throwable error = new Exception();
+    CrashReport reportMock = mock(CrashReport.class);
+    CrashEvent crashEvent = new CrashEvent(null, null);
+    when(reportFactoryMock.createReportForNonFatal(error)).thenReturn(reportMock);
+    doReturn(crashEvent).when(reporter).parseReportAsEvent(reportMock);
+    when(telemetryMock.push(crashEvent)).thenReturn(true);
+
+    boolean isReported = reporter.reportError(error);
+
+    verify(telemetryMock, times(1)).push(crashEvent);
+    Assert.assertTrue(isReported);
+  }
+}


### PR DESCRIPTION
This PR:
1) Adds support for reporting non-fatal exceptions via Telemetry SDK (in a similar way to iOS Telemetry SDK);
2) Improve `stackTrace` information: `stackTrace` now keeps more information about original stack trace (more classes might be allowed for keeping in stack trace, exception message also added to stack trace);
3) Fixes failed `SchemaTest`.