### PR TITLE
[telemetry] Fix a wake-up on location update.

### DIFF
--- a/libtelemetry/src/full/AndroidManifest.xml
+++ b/libtelemetry/src/full/AndroidManifest.xml
@@ -21,5 +21,10 @@
 
         <service android:name=".MapboxTelemetryService" android:exported="false"/>
 
+        <receiver android:name="com.mapbox.android.telemetry.location.LocationUpdatesBroadcastReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="com.mapbox.android.telemetry.location.LocationUpdatesBroadcastReceiver.ACTION_LOCATION_UPDATED"/>
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationEngineControllerImpl.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/location/LocationEngineControllerImpl.java
@@ -50,7 +50,7 @@ class LocationEngineControllerImpl implements LocationEngineController {
   private void registerReceiver() {
     try {
       applicationContext.registerReceiver(locationUpdatesBroadcastReceiver,
-        new IntentFilter(LocationUpdatesBroadcastReceiver.ACTION_LOCATION_UPDATED));
+          new IntentFilter(LocationUpdatesBroadcastReceiver.ACTION_LOCATION_UPDATED));
     } catch (IllegalArgumentException iae) {
       Log.e(TAG, iae.toString());
     }
@@ -83,8 +83,8 @@ class LocationEngineControllerImpl implements LocationEngineController {
   }
 
   private PendingIntent getPendingIntent() {
-    // Implicit intent is required here to work with registering receiver via context
-    Intent intent = new Intent(LocationUpdatesBroadcastReceiver.ACTION_LOCATION_UPDATED);
+    Intent intent = new Intent(applicationContext, LocationUpdatesBroadcastReceiver.class);
+    intent.setAction(LocationUpdatesBroadcastReceiver.ACTION_LOCATION_UPDATED);
     return PendingIntent.getBroadcast(applicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 


### PR DESCRIPTION
In order for the platform to wake-up an app for a location update. we should:
 * expose LocationUpdatesBroadcastReceiver in the manifest;
 * explicitly register pending intent with an app context;