### PR TITLE
Improve non-fatal errors reporting

### DIFF
--- a/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportInstrumentedTest.java
+++ b/libcore/src/androidTest/java/com/mapbox/android/core/crashreporter/CrashReportInstrumentedTest.java
@@ -2,11 +2,15 @@ package com.mapbox.android.core.crashreporter;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
@@ -21,6 +25,11 @@ public class CrashReportInstrumentedTest {
 
   private final String invalidJson = "{"
     + "  \"locations\": [ 94043, 90210"
+    + "}";
+
+  private final String defaultJsonTemplate = "{"
+    + "\"event\": \"mobile.crash\", "
+    + "\"created\": \"2021-01-10T12:00:00.000+0200\""
     + "}";
 
   @Test
@@ -53,5 +62,32 @@ public class CrashReportInstrumentedTest {
   public void checkDateCreated() {
     CrashReport report = new CrashReport(new GregorianCalendar());
     assertFalse(report.getDateString().isEmpty());
+  }
+
+  @Test
+  public void putJSONArray() throws JSONException {
+    CrashReport report = new CrashReport(defaultJsonTemplate);
+    Map<String, String> map = new HashMap<>(4);
+    map.put("foo", "bar");
+    Map<String, String> map2 = new HashMap<>(4);
+    map2.put("testKey", "testValue");
+    JSONArray jsonArray = new JSONArray(Arrays.asList(map, map2));
+    report.put("customData", jsonArray);
+
+    assertEquals(
+      ("{"
+        + "    \"event\": \"mobile.crash\","
+        + "    \"created\": \"2021-01-10T12:00:00.000+0200\","
+        + "    \"customData\": ["
+        + "        {"
+        + "            \"foo\": \"bar\""
+        + "        },"
+        + "        {"
+        + "            \"testKey\": \"testValue\""
+        + "        }"
+        + "    ]"
+        + "}").replace(" ", ""),  // To remove pretty printing from JSON
+      report.toJson()
+    );
   }
 }

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReport.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReport.java
@@ -4,6 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import android.util.Log;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -36,7 +38,7 @@ public class CrashReport {
    * @param key   valid non-empty key
    * @param value valid string value or null
    */
-  public synchronized void put(@NonNull String key, @Nullable String value) {
+  public synchronized void put(@NonNull String key, @Nullable Object value) {
     if (value == null) {
       putNull(key);
       return;
@@ -45,7 +47,7 @@ public class CrashReport {
     try {
       this.content.put(key, value);
     } catch (JSONException je) {
-      Log.e(TAG, "Failed json encode value: " + String.valueOf(value));
+      Log.e(TAG, "Failed json encode value: " + value);
     }
   }
 
@@ -73,6 +75,12 @@ public class CrashReport {
   @NonNull
   String getString(@NonNull String key) {
     return this.content.optString(key);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  JSONArray getJsonArray(@NonNull String key) {
+    return this.content.optJSONArray(key);
   }
 
   private void putNull(@NonNull String key) {

--- a/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReportFactory.java
+++ b/libcore/src/main/java/com/mapbox/android/core/crashreporter/CrashReportFactory.java
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -45,7 +46,25 @@ public final class CrashReportFactory {
    *         is returned
    */
   @Nullable
-  public CrashReport createReportForCrash(Thread thread, Throwable throwable) {
+  public CrashReport createReportForCrash(@Nullable Thread thread,
+                                          @Nullable Throwable throwable) {
+    return createReportForCrash(thread, throwable, null);
+  }
+
+  /**
+   * Create {@link CrashReport} for crash.
+   *
+   * @param thread thread, where exception has occurred
+   * @param throwable crash itself
+   * @param customData extra information useful for report, provided by the user
+   * @return report, if crash was partly or fully caused by Mapbox module/sdk with
+   *         {@linkplain CrashReportFactory#mapboxPackage} package name; otherwise, null
+   *         is returned
+   */
+  @Nullable
+  public CrashReport createReportForCrash(@Nullable Thread thread,
+                                          @Nullable Throwable throwable,
+                                          @Nullable Map<String, String> customData) {
     CrashReport report = null;
 
     List<Throwable> causalChain;
@@ -54,6 +73,7 @@ public final class CrashReportFactory {
         .setup(applicationContext, mapboxPackage, mapboxModuleVersion, allowedStacktracePrefixes)
         .addExceptionThread(thread)
         .addCausalChain(causalChain)
+        .setCustomData(customData)
         .build();
     }
 
@@ -69,7 +89,22 @@ public final class CrashReportFactory {
    *         is returned
    */
   @Nullable
-  public CrashReport createReportForNonFatal(Throwable throwable) {
+  public CrashReport createReportForNonFatal(@Nullable Throwable throwable) {
+    return createReportForNonFatal(throwable, null);
+  }
+
+  /**
+   * Create {@link CrashReport} for non-fatal error.
+   *
+   * @param throwable non-fatal error
+   * @param customData extra information useful for report, provided by the user
+   * @return report, if non-fatal error was partly or fully caused by Mapbox module/sdk with
+   *         {@linkplain CrashReportFactory#mapboxPackage} package name; otherwise, null
+   *         is returned
+   */
+  @Nullable
+  public CrashReport createReportForNonFatal(@Nullable Throwable throwable,
+                                             @Nullable Map<String, String> customData) {
     CrashReport report = null;
 
     List<Throwable> causalChain;
@@ -78,6 +113,7 @@ public final class CrashReportFactory {
         .setup(applicationContext, mapboxPackage, mapboxModuleVersion, allowedStacktracePrefixes)
         .isSilent(true)
         .addCausalChain(causalChain)
+        .setCustomData(customData)
         .build();
     }
 

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/CrashEvent.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/CrashEvent.java
@@ -8,6 +8,8 @@ import androidx.annotation.Keep;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 /**
  * This class is temporary and exists only
  * to comply with legacy telemetry interface,
@@ -45,6 +47,8 @@ public class CrashEvent extends Event {
   private String appId;
   @SerializedName("appVersion")
   private String appVersion;
+  @SerializedName("customData")
+  private List<KeyValue> customData;
 
   public CrashEvent(String event, String created) {
     this.event = event;

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/KeyValue.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/KeyValue.java
@@ -1,0 +1,33 @@
+package com.mapbox.android.telemetry;
+
+import android.annotation.SuppressLint;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.Keep;
+
+import com.google.gson.annotations.SerializedName;
+
+@SuppressLint("ParcelCreator")
+@Keep
+class KeyValue implements Parcelable {
+  @SerializedName("name")
+  private final String name;
+  @SerializedName("value")
+  private final String value;
+
+  public KeyValue(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    // no-op
+  }
+}

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
@@ -1,12 +1,14 @@
 package com.mapbox.android.telemetry;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.android.core.crashreporter.CrashReport;
 import com.mapbox.android.core.crashreporter.CrashReportFactory;
 import com.mapbox.android.telemetry.errors.ErrorUtils;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -39,8 +41,20 @@ public class MapboxCrashReporter {
    * @param throwable non-fatal error, that should be reported
    * @return whether error event was added to event queue
    */
-  public boolean reportError(Throwable throwable) {
-    CrashReport report = crashReportFactory.createReportForNonFatal(throwable);
+  public boolean reportError(@NonNull Throwable throwable) {
+    return reportError(throwable, null);
+  }
+
+  /**
+   * Report non-fatal exception via Telemetry.
+   *
+   * @param throwable non-fatal error, that should be reported
+   * @param customData extra data, provided by SDK consumer
+   * @return whether error event was added to event queue
+   */
+  public boolean reportError(@NonNull Throwable throwable,
+                             @Nullable Map<String, String> customData) {
+    CrashReport report = crashReportFactory.createReportForNonFatal(throwable, customData);
     if (report != null) {
       CrashEvent nonFatalErrorEvent = parseReportAsEvent(report);
       return telemetry.push(nonFatalErrorEvent);

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxCrashReporter.java
@@ -57,7 +57,7 @@ public class MapboxCrashReporter {
     CrashReport report = crashReportFactory.createReportForNonFatal(throwable, customData);
     if (report != null) {
       CrashEvent nonFatalErrorEvent = parseReportAsEvent(report);
-      return telemetry.push(nonFatalErrorEvent);
+      return telemetry.pushToQueue(nonFatalErrorEvent);
     }
     return false;
   }

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/MapboxTelemetry.java
@@ -326,7 +326,7 @@ public class MapboxTelemetry implements FullQueueCallback, ServiceTaskCallback {
     attachmentListeners = new CopyOnWriteArraySet<>();
   }
 
-  private boolean pushToQueue(Event event) {
+  boolean pushToQueue(Event event) {
     TelemetryEnabler.State telemetryState = telemetryEnabler.obtainTelemetryState();
     if (TelemetryEnabler.State.ENABLED.equals(telemetryState)) {
       return queue.push(event);

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
@@ -32,7 +32,7 @@ public class MapboxCrashReporterTest {
 
     boolean isReported = reporter.reportError(error, customData);
 
-    verify(telemetryMock, never()).push(any(Event.class));
+    verify(telemetryMock, never()).pushToQueue(any(Event.class));
     Assert.assertFalse(isReported);
   }
 
@@ -48,11 +48,11 @@ public class MapboxCrashReporterTest {
     CrashEvent crashEvent = new CrashEvent(null, null);
     when(reportFactoryMock.createReportForNonFatal(error, customData)).thenReturn(reportMock);
     doReturn(crashEvent).when(reporter).parseReportAsEvent(reportMock);
-    when(telemetryMock.push(crashEvent)).thenReturn(true);
+    when(telemetryMock.pushToQueue(crashEvent)).thenReturn(true);
 
     boolean isReported = reporter.reportError(error, customData);
 
-    verify(telemetryMock, times(1)).push(crashEvent);
+    verify(telemetryMock, times(1)).pushToQueue(crashEvent);
     Assert.assertTrue(isReported);
   }
 }

--- a/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
+++ b/libtelemetry/src/testFull/java/com/mapbox/android/telemetry/MapboxCrashReporterTest.java
@@ -6,6 +6,9 @@ import com.mapbox.android.core.crashreporter.CrashReportFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -19,14 +22,15 @@ public class MapboxCrashReporterTest {
 
   @Test
   public void reportNonMapboxException() {
+    Map<String, String> customData = Collections.emptyMap();
     MapboxTelemetry telemetryMock = mock(MapboxTelemetry.class);
     CrashReportFactory reportFactoryMock = mock(CrashReportFactory.class);
     MapboxCrashReporter reporter = new MapboxCrashReporter(telemetryMock, reportFactoryMock);
 
     Throwable error = new Exception();
-    when(reportFactoryMock.createReportForNonFatal(error)).thenReturn(null);
+    when(reportFactoryMock.createReportForNonFatal(error, customData)).thenReturn(null);
 
-    boolean isReported = reporter.reportError(error);
+    boolean isReported = reporter.reportError(error, customData);
 
     verify(telemetryMock, never()).push(any(Event.class));
     Assert.assertFalse(isReported);
@@ -34,6 +38,7 @@ public class MapboxCrashReporterTest {
 
   @Test
   public void reportMapboxException() {
+    Map<String, String> customData = Collections.emptyMap();
     MapboxTelemetry telemetryMock = mock(MapboxTelemetry.class);
     CrashReportFactory reportFactoryMock = mock(CrashReportFactory.class);
     MapboxCrashReporter reporter = spy(new MapboxCrashReporter(telemetryMock, reportFactoryMock));
@@ -41,11 +46,11 @@ public class MapboxCrashReporterTest {
     Throwable error = new Exception();
     CrashReport reportMock = mock(CrashReport.class);
     CrashEvent crashEvent = new CrashEvent(null, null);
-    when(reportFactoryMock.createReportForNonFatal(error)).thenReturn(reportMock);
+    when(reportFactoryMock.createReportForNonFatal(error, customData)).thenReturn(reportMock);
     doReturn(crashEvent).when(reporter).parseReportAsEvent(reportMock);
     when(telemetryMock.push(crashEvent)).thenReturn(true);
 
-    boolean isReported = reporter.reportError(error);
+    boolean isReported = reporter.reportError(error, customData);
 
     verify(telemetryMock, times(1)).push(crashEvent);
     Assert.assertTrue(isReported);


### PR DESCRIPTION
This PR contains small improvements for non-fatal errors reporting:
1. Custom data support was added for non-fatal errors and crashes reporting;
2. Non-fatal errors are not sent immediately (for optimisation purpose).