### PR TITLE
Add a new hash for api-events-staging

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/StagingCertificatePins.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/StagingCertificatePins.java
@@ -15,6 +15,7 @@ class StagingCertificatePins {
           add("3euxrJOrEZI15R4104UsiAkDqe007EPyZ6eTL/XxdAY=");
           add("5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=");
           add("r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=");
+          add("PA1lecwXNRXY/Vpy0VN+jQEYChN4hCAF36oB0Ygx3wQ=");
         }
       });
     }


### PR DESCRIPTION
We just updated the certificate for `api-events-staging` and generated a new hash which I'm adding here to test pinning. 