### PR TITLE
Add 5 new pins for the staging endpoint 

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/StagingCertificatePins.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/StagingCertificatePins.java
@@ -16,6 +16,12 @@ class StagingCertificatePins {
           add("5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=");
           add("r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=");
           add("PA1lecwXNRXY/Vpy0VN+jQEYChN4hCAF36oB0Ygx3wQ=");
+          // new 2048 bit keys generated in April 2021
+          add("8apXPecP7X3vUGqi/B42cig4O1BjQUM4dng5gMVOiK0=");
+          add("MxGjtNVZ0mEdjhhfvAcTNZd+lC8WY8vKkkaSFE2azXQ=");
+          add("i/5fi5jB13JKeiZJMFNu4XSIaaCNmxAWsWvmMsI7t5s=");
+          add("4YJLMcE66WP2/FRID2HT0QpQRNjG7zqz/dJzP3BGct8=");
+          add("H1YTKuZacKUYyGnQFVPcarkqYxvGJ7QKb9dFz2TssKw=");
         }
       });
     }


### PR DESCRIPTION
Adding 5 new staging pins for 2048 bit keys. 

Part of [certificate rotation](https://github.com/mapbox/api-events/issues/701)