### PR TITLE
[telemetry] Downgrade getDataNetworkType() error to warning

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -174,7 +174,7 @@ public class TelemetryUtils {
       } catch (SecurityException se) {
         // Developer did not add READ_PHONE_STATE permission to their app
         // or user did not accept the permission.
-        Log.e(TAG, se.toString());
+        Log.w(TAG, se.toString());
       }
     } else {
       output = telephonyManager.getNetworkType();


### PR DESCRIPTION
If the app doesn't have the correct permissions and we handle this gracefully - this should be a warning