### PR TITLE
[telemetry] Workaround for `MapboxTelemetryService` crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Mapbox Android Telemetry
 
+### v7.0.3
+
+- [telemetry] Workaround for MapboxTelemetryService crash. [#531](https://github.com/mapbox/mapbox-events-android/pull/531)
+
 ### v7.0.2
+
 - Add 5 new pins for the staging endpoint [#519](https://github.com/mapbox/mapbox-events-android/pull/519)
 
 ### v7.0.1

--- a/libtelemetry/src/full/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
+++ b/libtelemetry/src/full/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
@@ -35,8 +35,12 @@ public class MapboxTelemetryInitProvider extends ContentProvider {
   private final ServiceConnection telemetryServiceConnection = new ServiceConnection() {
     @Override
     public void onServiceConnected(ComponentName name, IBinder service) {
-      MapboxTelemetryService.Binder binder = (MapboxTelemetryService.Binder) service;
-      telemetryService = binder.getService();
+      if (service instanceof MapboxTelemetryService.Binder) {
+        MapboxTelemetryService.Binder binder = (MapboxTelemetryService.Binder) service;
+        telemetryService = binder.getService();
+      } else {
+        Log.w(TAG, "Invalid type of MapboxTelemetryService.Binder=" + service);
+      }
     }
 
     @Override


### PR DESCRIPTION
Resolves #530.

Workaround for the crash that can happen in multiple processes of WorkManager. The service functionality is tracking the lifecycle of the app's activity, so in case of background tasks, we can safely ignore this error.
