### PR TITLE
[telemetry] Disable `MapboxTelemetryInitProvider` if the telemetry is disabled via app's manifest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Mapbox Android Telemetry
 
+### v8.0.1
+
+- [telemetry] Disable `MapboxTelemetryInitProvider` if the telemetry is disabled via app's manifest.
+
 ### v8.0.0
 
 - [telemetry] Added build flavours for OkHttp v3.x and v4.x

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryEnabler.java
@@ -84,7 +84,7 @@ public class TelemetryEnabler {
     return currentTelemetryState;
   }
 
-  static boolean isEventsEnabled(Context context) {
+  public static boolean isEventsEnabled(Context context) {
     try {
       ApplicationInfo appInformation = context.getPackageManager().getApplicationInfo(
         context.getPackageName(), PackageManager.GET_META_DATA);

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/provider/MapboxTelemetryInitProvider.java
@@ -21,6 +21,7 @@ import com.mapbox.android.telemetry.errors.TokenChangeBroadcastReceiver;
 import com.mapbox.android.telemetry.location.LocationCollectionClient;
 
 import java.util.concurrent.TimeUnit;
+import com.mapbox.android.telemetry.TelemetryEnabler;
 
 import static com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_TELEMETRY_PACKAGE;
 import static com.mapbox.android.telemetry.location.LocationCollectionClient.DEFAULT_SESSION_ROTATION_INTERVAL_HOURS;
@@ -56,6 +57,11 @@ public class MapboxTelemetryInitProvider extends ContentProvider {
 
       if (context == null) {
         Log.e(TAG, "Failed to initialize: context is null");
+        return false;
+      }
+
+      if (!TelemetryEnabler.isEventsEnabled(context)) {
+        Log.i(TAG, "telemetry is disabled, skip initialization.");
         return false;
       }
 


### PR DESCRIPTION
Do not run initialization via content provider if telemetry is permanently disabled through an app's manifest metadata.
