### PR TITLE
[build] Attach more info to Maven publications uploaded with sdkRegistry

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'maven-publish'
+apply plugin: 'com.mapbox.sdkRegistry'
+apply from: file('../gradle/artifact-settings.gradle')
+
+version = project.ext.versionName
+group = project.ext.mapboxArtifactGroupId
+
+ext.attachBasePomInfo = { pom ->
+    pom.withXml {
+        final mainNode = asNode()
+        mainNode.appendNode('name', project.property('mapboxArtifactTitle'))
+        mainNode.appendNode('description', project.property('mapboxArtifactDescription'))
+        mainNode.appendNode('url', project.property('mapboxArtifactUrl'))
+
+        final licenseNode = mainNode.appendNode('licenses').appendNode('license')
+        licenseNode.appendNode('name', project.property('mapboxArtifactLicenseName'))
+        licenseNode.appendNode('url', project.property('mapboxArtifactLicenseUrl'))
+        licenseNode.appendNode('distribution', "repo")
+
+        final developerNode = mainNode.appendNode('developers').appendNode('developer')
+        developerNode.appendNode('id', project.property('mapboxDeveloperId'))
+        developerNode.appendNode('name', project.property('mapboxDeveloperName'))
+
+        final scmNode = mainNode.appendNode("scm")
+        scmNode.appendNode("connection", project.property('mapboxArtifactScmUrl'))
+        scmNode.appendNode("developerConnection", project.property('mapboxArtifactScmUrl'))
+        scmNode.appendNode("url", project.property('mapboxArtifactUrl'))
+    }
+}

--- a/libcore/build.gradle
+++ b/libcore/build.gradle
@@ -52,12 +52,7 @@ dependencies {
 }
 
 
-apply plugin: 'maven-publish'
-apply plugin: 'com.mapbox.sdkRegistry'
-apply from: file('../gradle/artifact-settings.gradle')
-
-version = project.ext.versionName
-group = project.ext.mapboxArtifactGroupId
+apply from: file('../gradle/publish.gradle')
 
 afterEvaluate {
     publishing {
@@ -67,6 +62,11 @@ afterEvaluate {
                 groupId this.group
                 artifactId project.ext.mapboxArtifactId
                 version this.version
+
+                artifact(androidJavadocsJar)
+                artifact(androidSourcesJar)
+
+                attachBasePomInfo(pom)
             }
         }
     }

--- a/libtelemetry/build.gradle
+++ b/libtelemetry/build.gradle
@@ -74,12 +74,8 @@ dependencies {
     androidTestImplementation dependenciesList.testRules
 }
 
-apply plugin: 'maven-publish'
-apply plugin: 'com.mapbox.sdkRegistry'
-apply from: file('../gradle/artifact-settings.gradle')
 
-version = project.ext.versionName
-group = project.ext.mapboxArtifactGroupId
+apply from: file('../gradle/publish.gradle')
 
 afterEvaluate {
     publishing {
@@ -89,6 +85,11 @@ afterEvaluate {
                     groupId this.group
                     artifactId project.ext.mapboxArtifactId
                     version this.version
+
+                    artifact(androidJavadocsJar)
+                    artifact(androidSourcesJar)
+
+                    attachBasePomInfo(pom)
                 }
 
                 okhttp3Release(MavenPublication) {
@@ -96,6 +97,11 @@ afterEvaluate {
                     groupId this.group
                     artifactId project.ext.mapboxArtifactId + "-okhttp3"
                     version this.version
+
+                    artifact(androidJavadocsJar)
+                    artifact(androidSourcesJar)
+
+                    attachBasePomInfo(pom)
                 }
             }
     }


### PR DESCRIPTION
For `:libcore` and `:libtelemetry` artifacts downloaded from Mapbox Maven repository we cannot retrieve information about license, developers and etc. from POM file. This PR addresses this problem.