### PR TITLE
[telemetry] Fix crash when using `obtainCellularNetworkType`

### DIFF
--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TestCellularNetworkType.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/TestCellularNetworkType.java
@@ -1,10 +1,16 @@
 package com.mapbox.android.telemetry;
 
 import android.content.Context;
+import android.telephony.TelephonyManager;
+
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 public class TestCellularNetworkType {
   @Test
@@ -12,5 +18,16 @@ public class TestCellularNetworkType {
     Context context = InstrumentationRegistry.getInstrumentation().getContext();
     String cellularNetworkType = TelemetryUtils.obtainCellularNetworkType(context);
     Assert.assertFalse(cellularNetworkType.isEmpty());
+  }
+
+  @Test
+  public void testUnknownNetworkType() {
+    Context mockedContext = mock(Context.class);
+    TelephonyManager mockedTelephonyManager = mock(TelephonyManager.class);
+    when(mockedContext.getSystemService(any(String.class))).thenReturn(mockedTelephonyManager);
+    when(mockedTelephonyManager.getDataNetworkType()).thenReturn(TelephonyManager.NETWORK_TYPE_UNKNOWN);
+    Assert.assertEquals(TelemetryUtils.obtainCellularNetworkType(mockedContext), "Unknown");
+    when(mockedTelephonyManager.getDataNetworkType()).thenReturn(Integer.MAX_VALUE);
+    Assert.assertEquals(TelemetryUtils.obtainCellularNetworkType(mockedContext), "Unknown");
   }
 }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -179,7 +179,11 @@ public class TelemetryUtils {
     } else {
       output = telephonyManager.getNetworkType();
     }
-    return NETWORKS.get(output);
+    String foundTelemetryType = NETWORKS.get(output);
+    if (foundTelemetryType == null) {
+      return UNKNOWN;
+    }
+    return foundTelemetryType;
   }
 
   public static String obtainCurrentDate() {


### PR DESCRIPTION
`TelemetryUtils.obtainCellularNetworkType` is annotated with @NonNull
annotation meaning that this function should never return a null.
However before this change there was a way to return a null when
returned underlying network type is not covered in the `NETWORKS` map.