### PR TITLE
[libtelemetry] Add `@Keep` annotation to the AttachmentMetadata

### DIFF
--- a/cloud_test.sh
+++ b/cloud_test.sh
@@ -19,6 +19,6 @@ gcloud firebase test android run --type instrumentation \
     --timeout 20m
 
 bucket="test-lab-r47d1tyt8h0hm-iku3c1i8kjrux"
-artifacts_path="hammerhead-23-en-landscape/artifacts"
+artifacts_path="hammerhead-23-en-landscape/artifacts/sdcard"
 covfile_path="gs://${bucket}/${results_dir}/${artifacts_path}/${module}_coverage.ec"
 gsutil cp $covfile_path "${build_dir}/jacoco"

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/AttachmentMetadata.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/AttachmentMetadata.java
@@ -1,5 +1,8 @@
 package com.mapbox.android.telemetry;
 
+import androidx.annotation.Keep;
+
+@Keep
 public class AttachmentMetadata {
 
   private String name;


### PR DESCRIPTION
This will prevent Proguard / obfuscation issues with `AttachmentMetadata`
class.