### PR TITLE
[location] Add new field `permissionStatus` to location events

### DIFF
--- a/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
@@ -63,7 +63,7 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
       public void onClick(View v) {
         for (int i = 0; i < 180; i++) {
           mapboxTelemetry.push(
-            new LocationEvent("testSessionId", 0.0, 0.0, "testAppState"))
+            new LocationEvent("testSessionId", 0.0, 0.0, "testAppState", "testPermissionStatus"))
           ;
         }
       }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
@@ -35,8 +35,11 @@ public class LocationEvent extends Event implements Parcelable {
   private String applicationState;
   @SerializedName("horizontalAccuracy")
   private Float accuracy = null;
+  @SerializedName("permissionStatus")
+  private final String permissionStatus;
 
-  public LocationEvent(String sessionId, double latitude, double longitude, String applicationState) {
+  public LocationEvent(String sessionId, double latitude, double longitude,
+                       String applicationState, String permissionStatus) {
     this.event = LOCATION;
     this.created = TelemetryUtils.obtainCurrentDate();
     this.source = SOURCE_MAPBOX;
@@ -45,6 +48,7 @@ public class LocationEvent extends Event implements Parcelable {
     this.longitude = longitude;
     this.operatingSystem = OPERATING_SYSTEM;
     this.applicationState = applicationState;
+    this.permissionStatus = permissionStatus;
   }
 
   @Override
@@ -99,6 +103,7 @@ public class LocationEvent extends Event implements Parcelable {
     operatingSystem = in.readString();
     applicationState = in.readString();
     accuracy = in.readByte() == 0x00 ? null : in.readFloat();
+    permissionStatus = in.readString();
   }
 
   @Override
@@ -128,6 +133,7 @@ public class LocationEvent extends Event implements Parcelable {
       dest.writeByte((byte) (0x01));
       dest.writeFloat(accuracy);
     }
+    dest.writeString(permissionStatus);
   }
 
   @SuppressWarnings("unused")

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/location/LocationMapper.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/location/LocationMapper.java
@@ -16,26 +16,30 @@ public class LocationMapper {
 
   @Deprecated
   public static LocationEvent create(Location location, String sessionId) {
-    return createLocationEvent(location, "unknown", sessionId);
+    return createLocationEvent(location, "unknown", sessionId, "Allow");
   }
 
-  public static LocationEvent create(Location location, String applicationState, String sessionId) {
-    return createLocationEvent(location, applicationState, sessionId);
+  public static LocationEvent create(Location location, String applicationState,
+                                     String sessionId, String permissionStatus) {
+    return createLocationEvent(location, applicationState, sessionId, permissionStatus);
   }
 
-  public LocationEvent from(Location location, String applicationState) {
-    return createLocationEvent(location, applicationState, sessionIdentifier.getSessionId());
+  public LocationEvent from(Location location, String applicationState, String permissionStatus) {
+    return createLocationEvent(location, applicationState,
+            sessionIdentifier.getSessionId(), permissionStatus);
   }
 
   public void updateSessionIdentifier(SessionIdentifier sessionIdentifier) {
     this.sessionIdentifier = sessionIdentifier;
   }
 
-  private static LocationEvent createLocationEvent(Location location, String applicationState, String sessionId) {
+  private static LocationEvent createLocationEvent(Location location, String applicationState,
+                                                   String sessionId, String permissionStatus) {
     double latitudeScaled = round(location.getLatitude());
     double longitudeScaled = round(location.getLongitude());
     double longitudeWrapped = wrapLongitude(longitudeScaled);
-    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped, applicationState);
+    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped,
+            applicationState, permissionStatus);
     addAltitudeIfPresent(location, locationEvent);
     addAccuracyIfPresent(location, locationEvent);
     return locationEvent;

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
@@ -32,7 +32,7 @@ public class LocationEventTest {
   private Event obtainALocationEvent() {
     float aLatitude = 40.416775f;
     float aLongitude = -3.703790f;
-    return new LocationEvent("anySessionId", aLatitude, aLongitude, "");
+    return new LocationEvent("anySessionId", aLatitude, aLongitude, "", "");
   }
 
   private void setupMockedContext() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationMapperTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationMapperTest.java
@@ -16,7 +16,7 @@ public class LocationMapperTest {
   public void checksLocationEventNameMapping() throws Exception {
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "", "");
     assertEquals("location", actualLocationEvent.getEvent());
   }
 
@@ -24,7 +24,7 @@ public class LocationMapperTest {
   public void checksLocationEventSourceMapping() throws Exception {
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"", "");
     assertEquals("mapbox", actualLocationEvent.getSource());
   }
 
@@ -33,7 +33,7 @@ public class LocationMapperTest {
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLatitude()).thenReturn(51.39430732403739);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "","");
     assertEquals(51.3943073, actualLocationEvent.getLatitude(), 0);
   }
 
@@ -42,7 +42,7 @@ public class LocationMapperTest {
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(-147.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "","");
     assertEquals(-147.7322583, actualLocationEvent.getLongitude(), 0);
   }
 
@@ -50,7 +50,7 @@ public class LocationMapperTest {
   public void checksLocationEventOperatingSystemMapping() throws Exception {
     Location mockedLocation = mock(Location.class);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"","");
     assertTrue(actualLocationEvent.getOperatingSystem().startsWith("Android - "));
   }
 
@@ -60,7 +60,7 @@ public class LocationMapperTest {
     when(mockedLocation.hasAltitude()).thenReturn(true);
     when(mockedLocation.getAltitude()).thenReturn(23.43);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "","");
     assertEquals(23.0, actualLocationEvent.getAltitude(), 0);
   }
 
@@ -70,7 +70,7 @@ public class LocationMapperTest {
     when(mockedLocation.hasAccuracy()).thenReturn(true);
     when(mockedLocation.getAccuracy()).thenReturn(1.9f);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "","");
     assertEquals(2.0, actualLocationEvent.getAccuracy(), 0);
   }
 
@@ -79,7 +79,7 @@ public class LocationMapperTest {
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(187.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation,"","");
     assertEquals(-172.2677417, actualLocationEvent.getLongitude(), 0);
   }
 
@@ -88,7 +88,7 @@ public class LocationMapperTest {
     Location mockedLocation = mock(Location.class);
     when(mockedLocation.getLongitude()).thenReturn(-187.73225836990392);
     LocationMapper obtainLocationEvent = new LocationMapper();
-    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "");
+    LocationEvent actualLocationEvent = obtainLocationEvent.from(mockedLocation, "","");
     assertEquals(172.2677417, actualLocationEvent.getLongitude(), 0);
   }
 }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/SchemaTest.java
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
@@ -84,6 +85,15 @@ public class SchemaTest {
     }
     List<Field> fields = grabClassFields(LocationEvent.class);
 
+    // temporary solution until backend gets support for the "permissionStatus" field
+    Iterator<Field> iterator = fields.iterator();
+    while (iterator.hasNext()) {
+      Field p = iterator.next();
+      if (p.getName().equals("permissionStatus")) {
+        iterator.remove();
+      }
+    }
+
     assertEquals(schema.size(), fields.size());
   }
 
@@ -91,6 +101,15 @@ public class SchemaTest {
   public void checkLocationEventFields() throws Exception {
     JsonObject schema = grabSchema(LOCATION);
     List<Field> fields = grabClassFields(LocationEvent.class);
+
+    // temporary solution until backend gets support for the "permissionStatus" field
+    Iterator<Field> iterator = fields.iterator();
+    while (iterator.hasNext()) {
+      Field p = iterator.next();
+      if (p.getName().equals("permissionStatus")) {
+        iterator.remove();
+      }
+    }
 
     schemaContainsFields(schema, fields);
   }

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
@@ -29,7 +29,7 @@ public class TelemetryClientLocationEventTest extends MockWebServerTest {
       "reformedUserAgent", mockedContext);
     double aLatitude = 40.416775;
     double aLongitude = -3.703790;
-    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude, "");
+    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude, "", "");
     List<Event> theLocationEvent = obtainEvents(aLocationEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();


### PR DESCRIPTION
With this change, we are adding extra information about granted location permission to the location events:

* `AllowAlways` means that the end-user is allowed to collect location information while an application is in the background.
* `AllowWhenInUse` means that the end-user is allowed to collect location information while an application is in the foreground or only one-time access was granted.
 