### PR TITLE
[libtelemetry] Fix LocationEvent timestamp.

### DIFF
--- a/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/events/testapp/MainActivity.java
@@ -63,7 +63,8 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
       public void onClick(View v) {
         for (int i = 0; i < 180; i++) {
           mapboxTelemetry.push(
-            new LocationEvent("testSessionId", 0.0, 0.0, "testAppState", "testPermissionStatus"))
+            new LocationEvent("testSessionId", 0.0, 0.0,
+                    System.currentTimeMillis(), "testAppState", "testPermissionStatus"))
           ;
         }
       }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
@@ -38,10 +38,10 @@ public class LocationEvent extends Event implements Parcelable {
   @SerializedName("permissionStatus")
   private final String permissionStatus;
 
-  public LocationEvent(String sessionId, double latitude, double longitude,
+  public LocationEvent(String sessionId, double latitude, double longitude, long timestampUtcMs,
                        String applicationState, String permissionStatus) {
     this.event = LOCATION;
-    this.created = TelemetryUtils.obtainCurrentDate();
+    this.created = TelemetryUtils.obtainCurrentDate(timestampUtcMs);
     this.source = SOURCE_MAPBOX;
     this.sessionId = sessionId;
     this.latitude = latitude;
@@ -49,6 +49,12 @@ public class LocationEvent extends Event implements Parcelable {
     this.operatingSystem = OPERATING_SYSTEM;
     this.applicationState = applicationState;
     this.permissionStatus = permissionStatus;
+  }
+
+  @Deprecated
+  public LocationEvent(String sessionId, double latitude, double longitude,
+                       String applicationState, String permissionStatus) {
+    this(sessionId, latitude, longitude, System.currentTimeMillis(), applicationState, permissionStatus);
   }
 
   @Override

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryUtils.java
@@ -172,6 +172,10 @@ public class TelemetryUtils {
     return foundTelemetryType;
   }
 
+  public static String obtainCurrentDate(long timeMsUtc) {
+    return dateFormat.format(new Date(timeMsUtc));
+  }
+
   public static String obtainCurrentDate() {
     return dateFormat.format(new Date());
   }

--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/location/LocationMapper.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/location/LocationMapper.java
@@ -38,7 +38,7 @@ public class LocationMapper {
     double latitudeScaled = round(location.getLatitude());
     double longitudeScaled = round(location.getLongitude());
     double longitudeWrapped = wrapLongitude(longitudeScaled);
-    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped,
+    LocationEvent locationEvent = new LocationEvent(sessionId, latitudeScaled, longitudeWrapped, location.getTime(),
             applicationState, permissionStatus);
     addAltitudeIfPresent(location, locationEvent);
     addAccuracyIfPresent(location, locationEvent);

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/LocationEventTest.java
@@ -32,7 +32,7 @@ public class LocationEventTest {
   private Event obtainALocationEvent() {
     float aLatitude = 40.416775f;
     float aLongitude = -3.703790f;
-    return new LocationEvent("anySessionId", aLatitude, aLongitude, "", "");
+    return new LocationEvent("anySessionId", aLatitude, aLongitude, System.currentTimeMillis(), "", "");
   }
 
   private void setupMockedContext() {

--- a/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
+++ b/libtelemetry/src/test/java/com/mapbox/android/telemetry/TelemetryClientLocationEventTest.java
@@ -29,7 +29,7 @@ public class TelemetryClientLocationEventTest extends MockWebServerTest {
       "reformedUserAgent", mockedContext);
     double aLatitude = 40.416775;
     double aLongitude = -3.703790;
-    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude, "", "");
+    Event aLocationEvent = new LocationEvent("aSessionId", aLatitude, aLongitude, System.currentTimeMillis(), "", "");
     List<Event> theLocationEvent = obtainEvents(aLocationEvent);
     Callback mockedCallback = mock(Callback.class);
     enqueueMockResponse();


### PR DESCRIPTION
Take the timestamp of the location fix not from a system clock, but from the fix itself (i.e. value populated by system geolocation service).
