### PR TITLE
[libtelemetry] Add `LocationEvent` constructor that doesn't accept `permissionStatus`

### DIFF
--- a/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
+++ b/libtelemetry/src/main/java/com/mapbox/android/telemetry/LocationEvent.java
@@ -57,6 +57,12 @@ public class LocationEvent extends Event implements Parcelable {
     this(sessionId, latitude, longitude, System.currentTimeMillis(), applicationState, permissionStatus);
   }
 
+  @Deprecated
+  public LocationEvent(String sessionId, double latitude, double longitude, long timestampUtcMs,
+                       String applicationState) {
+    this(sessionId, latitude, longitude, timestampUtcMs, applicationState, "unknown");
+  }
+
   @Override
   Type obtainType() {
     return Type.LOCATION;


### PR DESCRIPTION
In #566 we added `permissionStatus` parameter to the `LocationEvent` constructor. That change actually introduced a breaking change in the public API surface.
With this change, we are bringing an old constructor back and we use the `unknown` default value for the `permissionStatus`.