### PR TITLE
Remove public maven repo publication.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,16 +109,6 @@ jobs:
                 echo "export AWS_SDK_LOAD_CONFIG=1" >> $BASH_ENV
                 ./mbx-ci aws setup
       - run:
-          name: Generate Maven credentials
-          shell: /bin/bash -euo pipefail
-          command: |
-            aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg secring.gpg
-            echo "NEXUS_USERNAME=$PUBLISH_NEXUS_USERNAME
-            NEXUS_PASSWORD=$PUBLISH_NEXUS_PASSWORD
-            signing.keyId=$SIGNING_KEYID
-            signing.password=$SIGNING_PASSWORD
-            signing.secretKeyRingFile=../secring.gpg" >> gradle.properties
-      - run:
           name: Update version name
           command: |
             if [[ $CIRCLE_TAG == telem-* ]]; then

--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,13 @@ javadoc:
 	./gradlew :libcore:javadocrelease
 	./gradlew :libtelemetry:javadocokhttp4Release
 
-publish-core:
-	export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libcore:uploadArchives
-
-publish-telem:
-	export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libtelemetry:uploadArchives
-
 publish-local-core:
 	# This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
-	export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libcore:uploadArchives
+	./gradlew :libcore:uploadArchives
 
 publish-local-telem:
 	# This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
-	export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libtelemetry:uploadArchives
+	./gradlew :libtelemetry:uploadArchives
 
 .PHONY: publish-core-to-sdk-registry
 publish-core-to-sdk-registry:

--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -21,33 +21,8 @@ def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
-def static isLocalBuild() {
-    if (System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
-        return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
-    }
-    return true
-}
-
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
-}
-
 def obtainMavenLocalUrl() {
     return getRepositories().mavenLocal().getUrl()
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
 afterEvaluate { project ->
@@ -60,16 +35,7 @@ afterEvaluate { project ->
                 pom.artifactId = POM_ARTIFACT_ID
                 pom.version = VERSION_NAME
 
-                if (isLocalBuild()) {
-                    repository(url: obtainMavenLocalUrl())
-                } else {
-                    repository(url: getReleaseRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                }
+                repository(url: obtainMavenLocalUrl())
 
                 pom.project {
                     name POM_NAME


### PR DESCRIPTION
We do not practice maven repository publication for our projects anymore. We switched to our own sdk registry publication.
https://oss.sonatype.org/content/repositories/releases/ has very old mapbox versions (1 year and older for most projects).

we also never run `publish-core` and `publish-telem` by ci.