### PR TITLE
Remove maven publication follow-up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,17 +122,13 @@ jobs:
           name: Build libraries
           command: make release
       - deploy:
-          name: Publish to Maven Central and Mapbox SDK Registry
+          name: Publish to Mapbox SDK Registry
           command: |
             if [[ $CIRCLE_BRANCH == main ]]; then
-              make publish-core ;
-              make publish-telem ;
               make publish-all-to-sdk-registry ;
             elif [[ $CIRCLE_TAG == telem-* ]]; then
-              make publish-telem ;
               make publish-telemetry-to-sdk-registry ;
             elif [[ $CIRCLE_TAG == core-* ]]; then
-              make publish-core ;
               make publish-core-to-sdk-registry ;
             else
               echo "Skip, not a release branch"

--- a/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/AlarmMangerInstrumentationTest.java
+++ b/libtelemetry/src/androidTest/java/com/mapbox/android/telemetry/AlarmMangerInstrumentationTest.java
@@ -3,6 +3,7 @@ package com.mapbox.android.telemetry;
 import android.app.AlarmManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Assert;
@@ -19,6 +20,11 @@ public class AlarmMangerInstrumentationTest {
 
   @Test
   public void checksAlarmCancelledProperly() throws InterruptedException {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+      // AlarmSchedulerFlusher does not support SDK versions < KitKat.
+      return;
+    }
+
     final CountDownLatch latch = new CountDownLatch(2);
     final AtomicReference<Integer> broadcastTrack = new AtomicReference<>();
 


### PR DESCRIPTION
Mapbox does not practice publication of builds to public maven repo anymore